### PR TITLE
Add a breadcrumb bar to each page to aid website navigation

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,7 +11,7 @@
         <link href="{{ site.baseurl }}/debug.css" rel="stylesheet" type="text/css">
     </head>
     <body>
-        <div id="content">
+        <div id="container">
             <header>
                 <a href="{{ site.baseurl }}/index.html">
                     <img src="{{ site.baseurl }}/logo.png" alt="TMC Website Logo">
@@ -36,7 +36,7 @@
                 </div>
             </nav>
             {{ content }}
-            <footer>
+            <footer id="footer">
                 <span id="copyright">Copyright © Triumph Mayflower Club 2005-{{ "now" | date: "%Y" }}</span>
                 <span id="developer">Website designed and maintained by <a href="mailto:dev@stackinabox.com?subject=Triumph%20Mayflower%20Club%20Website">Andy Davies</a></span>
             </footer>

--- a/_layouts/emptycalendar.html
+++ b/_layouts/emptycalendar.html
@@ -11,7 +11,7 @@
         <link href="{{ site.baseurl }}/debug.css" rel="stylesheet" type="text/css">
     </head>
     <body>
-        <div id="content">
+        <div id="container">
             <header>
                 <a href="{{ site.baseurl }}/index.html">
                     <img src="{{ site.baseurl }}/logo.png" alt="TMC Website Logo">
@@ -37,8 +37,22 @@
             </nav>
             <main>
                 <article>
-                    <h1>Events in {{ page.region }}</h1>
-                    <p>Page content...</p>
+                    <ol id="breadcrumb">
+                        <li>
+                            <a href="{{ site.baseurl }}/index.html">Home</a>
+                        </li>
+                        <li>
+                            <a href="{{ site.baseurl }}/events/events.html">Events</a>
+                        </li>
+                        <li>
+                            <a href="{{ site.baseurl }}/events/calendars/calendars.html">Calendars</a>
+                        </li>
+                        <li>{{ page.region }}</li>
+                    </ol>
+                    <div id="content">
+                        <h1>Events in {{ page.prefix }}{{ page.region }}</h1>
+                        <p>Page content...</p>
+                    </div>
                 </article>
                 <aside>
                     <section>
@@ -53,7 +67,7 @@
                     </section>
                 </aside>
             </main>
-            <footer>
+            <footer id="footer">
                 <span id="copyright">Copyright © Triumph Mayflower Club 2005-{{ "now" | date: "%Y" }}</span>
                 <span id="developer">Website designed and maintained by <a href="mailto:dev@stackinabox.com?subject=Triumph%20Mayflower%20Club%20Website">Andy Davies</a></span>
             </footer>

--- a/common.css
+++ b/common.css
@@ -9,13 +9,6 @@ body {
     margin: 0 auto;
 }
 
-#content {
-    display: flex;
-    flex-direction: column;
-    position: relative;
-    min-height: 100vh;
-}
-
 header img {
     margin-left: -1px;
 }
@@ -37,27 +30,57 @@ nav ul li {
     padding-right: 20px;
 }
 
-nav #search {
-    padding: 15px 20px;
-}
-
 main {
     display: flex;
     padding-bottom: 50px;
     flex: 1;
 }
 
-main article {
-    flex: 1;
-    padding: 10px 20px;
+article {
+    flex: 1;    
 }
 
-main aside {
+aside {
     width: 230px;
     padding: 10px 20px;
 }
 
-footer {
+#container {
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    min-height: 100vh;
+}
+
+#search {
+    padding: 15px 20px;
+}
+
+#breadcrumb {
+    display: flex;
+    list-style: none;
+    margin: 0;
+    padding: 9px 20px 7px;
+}
+
+#breadcrumb li {
+    display: inline-block;
+}
+
+#breadcrumb li + li:before {
+    content: ">";
+    padding: 0 10px;
+}
+
+#breadcrumb li:last-child {
+    font-style: italic;
+}
+    
+#content {
+    padding: 10px 20px;
+}
+
+#footer {
     display: flex;
     align-items: center;
     position: absolute;
@@ -67,10 +90,10 @@ footer {
     padding: 0 20px;
 }
 
-footer #copyright {
+#copyright {
     flex: 1;
 }
 
-footer #developer {
+#developer {
     font-style: italic;
 }

--- a/contact/contact.html
+++ b/contact/contact.html
@@ -5,151 +5,159 @@ title: Contact
 
 <main>
     <article>
-        <h1>Contact</h1>
-        <section>
-            <h2>Chairman and regalia secretary</h2>
-            <div class="panelWithRightJustifiedImage">
-                <div class="content">
-                    <h3>John Castle</h3>
-                    <p>Phone: <a href="tel:+441455613041">(01455) 613041</a></p>
-                    <p>Email: <a href="mailto:john_castle@btinternet.com?subject=Triumph%20Mayflower%20Club">john_castle@btinternet.com</a></p>
-                    <p>Location: <a href="https://www.google.co.uk/maps/place/Hinckley">Hinckley, Leicestershire</a></p>
+        <ol id="breadcrumb">
+            <li>
+                <a href="{{ site.baseurl }}/index.html">Home</a>
+            </li>
+            <li>Contact</li>
+        </ol>
+        <div id="content">
+            <h1>Contact</h1>
+            <section>
+                <h2>Chairman and regalia secretary</h2>
+                <div class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <h3>John Castle</h3>
+                        <p>Phone: <a href="tel:+441455613041">(01455) 613041</a></p>
+                        <p>Email: <a href="mailto:john_castle@btinternet.com?subject=Triumph%20Mayflower%20Club">john_castle@btinternet.com</a></p>
+                        <p>Location: <a href="https://www.google.co.uk/maps/place/Hinckley">Hinckley, Leicestershire</a></p>
+                    </div>
+                    <img src="johncastle.jpg" alt="John Castle" height="130px">
                 </div>
-                <img src="johncastle.jpg" alt="John Castle" height="130px">
-            </div>
-        </section>
-        <section>
-            <h2>Vice chairman and rally secretary</h2>
-            <div class="panelWithRightJustifiedImage">
-                <div class="content">
-                    <h3>Chad Brown</h3>
-                    <p>Phone: <a href="tel:+447785561535">(07785) 561535</a></p>
-                    <p>Email: <a href="mailto:esperkymba@yahoo.co.uk?subject=Triumph%20Mayflower%20Club">esperkymba@yahoo.co.uk</a></p>
-                    <p>Location: <a href="https://www.google.co.uk/maps/place/Stretton+under+Fosse">Stretton-under-Fosse, Warwickshire</a></p>
+            </section>
+            <section>
+                <h2>Vice chairman and rally secretary</h2>
+                <div class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <h3>Chad Brown</h3>
+                        <p>Phone: <a href="tel:+447785561535">(07785) 561535</a></p>
+                        <p>Email: <a href="mailto:esperkymba@yahoo.co.uk?subject=Triumph%20Mayflower%20Club">esperkymba@yahoo.co.uk</a></p>
+                        <p>Location: <a href="https://www.google.co.uk/maps/place/Stretton+under+Fosse">Stretton-under-Fosse, Warwickshire</a></p>
+                    </div>
+                    <img src="chadbrown.jpg" alt="Chad Brown" height="130px">
                 </div>
-                <img src="chadbrown.jpg" alt="Chad Brown" height="130px">
-            </div>
-        </section>
-        <section>
-            <h2>General and membership secretary</h2>
-            <div class="panelWithRightJustifiedImage">
-                <div class="content">
-                    <h3>John Oaker</h3>
-                    <p>Phone: <a href="tel:+441922633042">(01922) 633042</a></p>
-                    <p>Email: <a href="mailto:johnchoaker@btinternet.com?subject=Triumph%20Mayflower%20Club">johnchoaker@btinternet.com</a></p>
-                    <p>Location: <a href="https://www.google.co.uk/maps/place/Walsall">Walsall, West Midlands</a></p>
+            </section>
+            <section>
+                <h2>General and membership secretary</h2>
+                <div class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <h3>John Oaker</h3>
+                        <p>Phone: <a href="tel:+441922633042">(01922) 633042</a></p>
+                        <p>Email: <a href="mailto:johnchoaker@btinternet.com?subject=Triumph%20Mayflower%20Club">johnchoaker@btinternet.com</a></p>
+                        <p>Location: <a href="https://www.google.co.uk/maps/place/Walsall">Walsall, West Midlands</a></p>
+                    </div>
+                    <img src="johnoaker.jpg" alt="John Oaker" height="130px">
                 </div>
-                <img src="johnoaker.jpg" alt="John Oaker" height="130px">
-            </div>
-        </section>
-        <section>
-            <h2>Spares secretary and coopted member</h2>
-            <div class="panelWithRightJustifiedImage">
-                <div class="content">
-                    <h3>Paul Burgess</h3>
-                    <p>Email: <a href="mailto:pburgess1956@gmail.com?subject=Triumph%20Mayflower%20Club">pburgess1956@gmail.com</a></p>
-                    <p>Location: <a href="https://www.google.co.uk/maps/place/Leicestershire">Leicestershire</a></p>
+            </section>
+            <section>
+                <h2>Spares secretary and coopted member</h2>
+                <div class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <h3>Paul Burgess</h3>
+                        <p>Email: <a href="mailto:pburgess1956@gmail.com?subject=Triumph%20Mayflower%20Club">pburgess1956@gmail.com</a></p>
+                        <p>Location: <a href="https://www.google.co.uk/maps/place/Leicestershire">Leicestershire</a></p>
+                    </div>
+                    <img src="{{ site.baseurl }}/paulburgess.jpg" alt="Paul Burgess" height="100px">
                 </div>
-                <img src="{{ site.baseurl }}/paulburgess.jpg" alt="Paul Burgess" height="100px">
-            </div>
-        </section>
-        <section>
-            <h2>Treasurer</h2>
-            <div class="panelWithRightJustifiedImage">
-                <div class="content">
-                    <h3>Paul Norton</h3>
-                    <p>Phone: <a href="tel:+441527575651">(01527) 575651</a></p>
-                    <p>Email: <a href="mailto:tvs520@hotmail.co.uk?subject=Triumph%20Mayflower%20Club">tvs520@hotmail.co.uk</a></p>
-                    <p>Location: <a href="https://www.google.co.uk/maps/place/Bromsgrove">Bromsgrove, Worcestershire</a></p>
+            </section>
+            <section>
+                <h2>Treasurer</h2>
+                <div class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <h3>Paul Norton</h3>
+                        <p>Phone: <a href="tel:+441527575651">(01527) 575651</a></p>
+                        <p>Email: <a href="mailto:tvs520@hotmail.co.uk?subject=Triumph%20Mayflower%20Club">tvs520@hotmail.co.uk</a></p>
+                        <p>Location: <a href="https://www.google.co.uk/maps/place/Bromsgrove">Bromsgrove, Worcestershire</a></p>
+                    </div>
                 </div>
-            </div>
-        </section>
-        <section>
-            <h2>Flower Power editor</h2>
-            <div class="panelWithRightJustifiedImage">
-                <div class="content">
-                    <h3>Nico ten Wolde</h3>
-                    <p>Email: <a href="mailto:webmastertmc@icloud.com?subject=Flower%20Power%20Magazine">webmastertmc@icloud.com</a></p>
-                    <p>Location: <a href="https://www.google.co.uk/maps/place/Utrecht">Utrecht, Netherlands</a></p>
+            </section>
+            <section>
+                <h2>Flower Power editor</h2>
+                <div class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <h3>Nico ten Wolde</h3>
+                        <p>Email: <a href="mailto:webmastertmc@icloud.com?subject=Flower%20Power%20Magazine">webmastertmc@icloud.com</a></p>
+                        <p>Location: <a href="https://www.google.co.uk/maps/place/Utrecht">Utrecht, Netherlands</a></p>
+                    </div>
+                    <img src="{{ site.baseurl }}/nicotenwolde.jpg" alt="Nico ten Wolde" height="100px">
                 </div>
-                <img src="{{ site.baseurl }}/nicotenwolde.jpg" alt="Nico ten Wolde" height="100px">
-            </div>
-        </section>
-        <section>
-            <h2>Flower Power publisher and coopted member</h2>
-            <div class="panelWithRightJustifiedImage">
-                <div class="content">
-                    <h3>John Gogay</h3>
-                    <p>Phone: <a href="tel:+441775760587">(01775) 760587</a></p>
-                    <p>Email: <a href="mailto:jgogay@aol.com?subject=Triumph%20Mayflower%20Club">jgogay@aol.com</a></p>
-                    <p>Location: <a href="https://www.google.co.uk/maps/place/Lincolnshire">Lincolnshire</a></p>
+            </section>
+            <section>
+                <h2>Flower Power publisher and coopted member</h2>
+                <div class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <h3>John Gogay</h3>
+                        <p>Phone: <a href="tel:+441775760587">(01775) 760587</a></p>
+                        <p>Email: <a href="mailto:jgogay@aol.com?subject=Triumph%20Mayflower%20Club">jgogay@aol.com</a></p>
+                        <p>Location: <a href="https://www.google.co.uk/maps/place/Lincolnshire">Lincolnshire</a></p>
+                    </div>
+                    <img src="{{ site.baseurl }}/johngogay.jpg" alt="John Gogay" height="130px">
                 </div>
-                <img src="{{ site.baseurl }}/johngogay.jpg" alt="John Gogay" height="130px">
-            </div>
-        </section>
-        <section>
-            <h2>Club historian and technical officer</h2>
-            <div class="panelWithRightJustifiedImage">
-                <div class="content">
-                    <h3>Steve Coulman</h3>
-                    <p>Phone: <a href="tel:+441724762061">(01724) 762061</a></p>
-                    <p>Email: <a href="mailto:nicouls@globalnet.co.uk?subject=Triumph%20Mayflower%20Club">nicouls@globalnet.co.uk</a></p>
-                    <p>Location: <a href="https://www.google.co.uk/maps/place/Messingham">Messingham, North Lincolnshire</a></p>
+            </section>
+            <section>
+                <h2>Club historian and technical officer</h2>
+                <div class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <h3>Steve Coulman</h3>
+                        <p>Phone: <a href="tel:+441724762061">(01724) 762061</a></p>
+                        <p>Email: <a href="mailto:nicouls@globalnet.co.uk?subject=Triumph%20Mayflower%20Club">nicouls@globalnet.co.uk</a></p>
+                        <p>Location: <a href="https://www.google.co.uk/maps/place/Messingham">Messingham, North Lincolnshire</a></p>
+                    </div>
                 </div>
-            </div>
-        </section>
-        <section>
-            <h2>Website editor and coopted member</h2>
-            <div class="panelWithRightJustifiedImage">
-                <div class="content">
-                    <h3>Rob Davies</h3>
-                    <p>Phone: <a href="tel:+441291623388">(01291) 623388</a></p>
-                    <p>Email: <a href="mailto:robertldavies@btinternet.com?subject=Triumph%20Mayflower%20Club">robertldavies@btinternet.com</a></p>
-                    <p>Location: <a href="https://www.google.co.uk/maps/place/Chepstow">Chepstow, Monmouthshire</a></p>
+            </section>
+            <section>
+                <h2>Website editor and coopted member</h2>
+                <div class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <h3>Rob Davies</h3>
+                        <p>Phone: <a href="tel:+441291623388">(01291) 623388</a></p>
+                        <p>Email: <a href="mailto:robertldavies@btinternet.com?subject=Triumph%20Mayflower%20Club">robertldavies@btinternet.com</a></p>
+                        <p>Location: <a href="https://www.google.co.uk/maps/place/Chepstow">Chepstow, Monmouthshire</a></p>
+                    </div>
+                    <img src="{{ site.baseurl }}/robdavies.jpg" alt="Rob Davies" height="130px">
                 </div>
-                <img src="{{ site.baseurl }}/robdavies.jpg" alt="Rob Davies" height="130px">
-            </div>
-        </section>
-        <section>
-            <h2>Technical officers</h2>
-            <div class="panelWithRightJustifiedImage">
-                <div class="content">
-                    <h3>Malcolm Barnsley</h3>
-                    <p>Phone: <a href="tel:+441732849140">(01732) 849140</a></p>
-                    <p>Email: <a href="mailto:judy.barnsley@hotmail.co.uk?subject=Triumph%20Mayflower%20Club">judy.barnsley@hotmail.co.uk</a></p>
-                    <p>Location: <a href="https://www.google.co.uk/maps/place/Aylesford">Aylesford, Kent</a></p>
+            </section>
+            <section>
+                <h2>Technical officers</h2>
+                <div class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <h3>Malcolm Barnsley</h3>
+                        <p>Phone: <a href="tel:+441732849140">(01732) 849140</a></p>
+                        <p>Email: <a href="mailto:judy.barnsley@hotmail.co.uk?subject=Triumph%20Mayflower%20Club">judy.barnsley@hotmail.co.uk</a></p>
+                        <p>Location: <a href="https://www.google.co.uk/maps/place/Aylesford">Aylesford, Kent</a></p>
+                    </div>
                 </div>
-            </div>
-            <div class="panelWithRightJustifiedImage">
-                <div class="content">
-                    <h3>Howard Pryor</h3>
-                    <p>Phone: <a href="tel:+442084408623">020 8440 8623</a></p>
-                    <p>Email: <a href="mailto:howard.pryor@tiscali.co.uk?subject=Triumph%20Mayflower%20Club">howard.pryor@tiscali.co.uk</a></p>
-                    <p>Location: <a href="https://www.google.co.uk/maps/place/High+Barnet">High Barnet, Hertfordshire</a></p>
+                <div class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <h3>Howard Pryor</h3>
+                        <p>Phone: <a href="tel:+442084408623">020 8440 8623</a></p>
+                        <p>Email: <a href="mailto:howard.pryor@tiscali.co.uk?subject=Triumph%20Mayflower%20Club">howard.pryor@tiscali.co.uk</a></p>
+                        <p>Location: <a href="https://www.google.co.uk/maps/place/High+Barnet">High Barnet, Hertfordshire</a></p>
+                    </div>
                 </div>
-            </div>
-            <div class="panelWithRightJustifiedImage">
-                <div class="content">
-                    <h3>John Leslie</h3>
-                    <p>Phone: <a href="tel:+64032170495">+64(0)3 2170495</a></p>
-                    <p>Email: <a href="mailto:johnl@southnet.co.nz?subject=Triumph%20Mayflower%20Club">johnl@southnet.co.nz</a></p>
-                    <p>Location: <a href="https://www.google.co.uk/maps/place/Invercargill">Invercargill, New Zealand</a></p>
+                <div class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <h3>John Leslie</h3>
+                        <p>Phone: <a href="tel:+64032170495">+64(0)3 2170495</a></p>
+                        <p>Email: <a href="mailto:johnl@southnet.co.nz?subject=Triumph%20Mayflower%20Club">johnl@southnet.co.nz</a></p>
+                        <p>Location: <a href="https://www.google.co.uk/maps/place/Invercargill">Invercargill, New Zealand</a></p>
+                    </div>
                 </div>
-            </div>
-        </section>
-        <section>
-            <h2>Webmaster</h2>
-            <div class="panelWithRightJustifiedImage">
-                <div class="content">
-                    <h3>Andy Davies</h3>
-                    <p>Phone: <a href="tel:+441291623388">(01291) 623388</a></p>
-                    <p>Email: <a href="mailto:dev@stackinabox.com?subject=Triumph%20Mayflower%20Club%20Website">dev@stackinabox.com</a></p>
-                    <p>Website: <a href="http://www.stackinabox.com/">http://www.stackinabox.com/</a></p>
-                    <p>Location: <a href="https://www.google.co.uk/maps/place/Chepstow">Chepstow, Monmouthshire</a></p>
+            </section>
+            <section>
+                <h2>Webmaster</h2>
+                <div class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <h3>Andy Davies</h3>
+                        <p>Phone: <a href="tel:+441291623388">(01291) 623388</a></p>
+                        <p>Email: <a href="mailto:dev@stackinabox.com?subject=Triumph%20Mayflower%20Club%20Website">dev@stackinabox.com</a></p>
+                        <p>Website: <a href="http://www.stackinabox.com/">http://www.stackinabox.com/</a></p>
+                        <p>Location: <a href="https://www.google.co.uk/maps/place/Chepstow">Chepstow, Monmouthshire</a></p>
+                    </div>
+                    <img src="andydavies.jpg" alt="Andy Davies" height="160px">
                 </div>
-                <img src="andydavies.jpg" alt="Andy Davies" height="160px">
-            </div>
-        </section>
+            </section>
+        </div>
     </article>
     <aside>
         <h2>Sidebar</h2>

--- a/debug.css
+++ b/debug.css
@@ -6,8 +6,13 @@ th, td {
     outline: 2px solid black;
 }
 
-#content {
+#container {
     outline: 2px solid black;
+}
+
+#breadcrumb {
+    outline: 1px solid black;
+    border-bottom: 0.5px solid black;
 }
 
 .imagePlaceholder {

--- a/documents/documents.html
+++ b/documents/documents.html
@@ -6,23 +6,31 @@ title: Documents
 <link href="documents.css" rel="stylesheet" type="text/css">
 <main>
     <article>
-        <h1>Documents</h1>
-        <section>
-            <a href="technical/technical.html">
-                <h2>Technical documentation</h2>
-            </a>
-            <p>Section blurb...</p>
-            <div id="technicalDocumentationImage" class="imagePlaceholder">Illustrative section image...</div>
-        </section>
-        <section>
-            <a href="flowerpowers/flowerpowers.html">
-                <h2>Flower Power archive</h2>
-            </a>
-            <p><i>Flower Power</i> is the periodical of the Triumph Mayflower Club. It is open for all members to contribute content to and is another forum for communication between members. This section aspires to include all issues ever published by the TMC over time.</p>
-            <a href="flowerpowers/flowerpowers.html">
-                <img src="flowerpowers.jpg" alt="Flower Power Archive">
-            </a>
-        </section>
+        <ol id="breadcrumb">
+            <li>
+                <a href="{{ site.baseurl }}/index.html">Home</a>
+            </li>
+            <li>Documents</li>
+        </ol>
+        <div id="content">
+            <h1>Documents</h1>
+            <section>
+                <a href="technical/technical.html">
+                    <h2>Technical documentation</h2>
+                </a>
+                <p>Section blurb...</p>
+                <div id="technicalDocumentationImage" class="imagePlaceholder">Illustrative section image...</div>
+            </section>
+            <section>
+                <a href="flowerpowers/flowerpowers.html">
+                    <h2>Flower Power archive</h2>
+                </a>
+                <p><i>Flower Power</i> is the periodical of the Triumph Mayflower Club. It is open for all members to contribute content to and is another forum for communication between members. This section aspires to include all issues ever published by the TMC over time.</p>
+                <a href="flowerpowers/flowerpowers.html">
+                    <img src="flowerpowers.jpg" alt="Flower Power Archive">
+                </a>
+            </section>
+        </div>
     </article>
     <aside>
         <h2>Sidebar</h2>

--- a/documents/flowerpowers/articles/articles.html
+++ b/documents/flowerpowers/articles/articles.html
@@ -5,375 +5,389 @@ title: Flower Power Technical Articles
 
 <main>
     <article>
-        <h1>Technical Articles Featured in Flower Power</h1>
-        <p>Over the years, Flower Power has featured a number of technical articles – mostly written by club members based on their own experience – pertaining to the maintenance of the Mayflower. This page contains a list of all such articles currently available on the website; the eventual goal is for all articles ever to be published in Flower Power since its inception to be available online in an accessible format, so that it forms a comprehensive handbook containing the club’s collective expertise.</p>
-        <p>To view an article in your browser, simply click the article title, page numbers or the thumbnail image which will open a new browser tab to the first page of said article. Alternatively, click the issue name followed by the download link to save a PDF copy of the whole Flower Power issue to your computer.</p>
-        <section>
-            <h2 id="accessories">Accessories</h2>
-            <section class="panelWithRightJustifiedImage">
-                <div class="content">
+        <ol id="breadcrumb">
+            <li>
+                <a href="{{ site.baseurl }}/index.html">Home</a>
+            </li>
+            <li>
+                <a href="{{ site.baseurl }}/documents/documents.html">Documents</a>
+            </li>
+            <li>
+                <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html">Flower Power Archive</a>
+            </li>
+            <li>Technical Articles</li>
+        </ol>
+        <div id="content">
+            <h1>Technical Articles Featured in Flower Power</h1>
+            <p>Over the years, Flower Power has featured a number of technical articles – mostly written by club members based on their own experience – pertaining to the maintenance of the Mayflower. This page contains a list of all such articles currently available on the website; the eventual goal is for all articles ever to be published in Flower Power since its inception to be available online in an accessible format, so that it forms a comprehensive handbook containing the club’s collective expertise.</p>
+            <p>To view an article in your browser, simply click the article title, page numbers or the thumbnail image which will open a new browser tab to the first page of said article. Alternatively, click the issue name followed by the download link to save a PDF copy of the whole Flower Power issue to your computer.</p>
+            <section>
+                <h2 id="accessories">Accessories</h2>
+                <section class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <a href="{{ site.baseurl }}/documents/flowerpowers/154.pdf#page=7" target="_blank">
+                            <h3>Tool roll</h3>
+                        </a>
+                        <p><b>Author:</b> Russ Hoenig</p>
+                        <p><b>Synopsis:</b> Manufacture of new tool roll.</p>
+                        <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#154">Winter/spring issue 2016 – № 154</a></p>
+                        <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/154.pdf#page=7" target="_blank">5, 7<a></a></p>
+                    </div>
                     <a href="{{ site.baseurl }}/documents/flowerpowers/154.pdf#page=7" target="_blank">
-                        <h3>Tool roll</h3>
+                        <img src="toolroll154.jpg" alt="Tool Roll" height="160px">
                     </a>
-                    <p><b>Author:</b> Russ Hoenig</p>
-                    <p><b>Synopsis:</b> Manufacture of new tool roll.</p>
-                    <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#154">Winter/spring issue 2016 – № 154</a></p>
-                    <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/154.pdf#page=7" target="_blank">5, 7<a></a></p>
-                </div>
-                <a href="{{ site.baseurl }}/documents/flowerpowers/154.pdf#page=7" target="_blank">
-                    <img src="toolroll154.jpg" alt="Tool Roll" height="160px">
-                </a>
+                </section>
             </section>
-        </section>
-        <section>
-            <h2 id="bodywork">Bodywork</h2>
-            <section class="panelWithRightJustifiedImage">
-                <div class="content">
+            <section>
+                <h2 id="bodywork">Bodywork</h2>
+                <section class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <a href="{{ site.baseurl }}/documents/flowerpowers/152.pdf#page=6" target="_blank">
+                            <h3>Mayflower body number tag</h3>
+                        </a>
+                        <p><b>Author:</b> Russ Hoenig</p>
+                        <p><b>Synopsis:</b> Offer to stamp a blank FISHOLOW tag for members.</p>
+                        <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#152">Spring issue 2015 – № 152</a></p>
+                        <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/152.pdf#page=6" target="_blank">4</a></p>
+                    </div>
                     <a href="{{ site.baseurl }}/documents/flowerpowers/152.pdf#page=6" target="_blank">
-                        <h3>Mayflower body number tag</h3>
+                        <img src="mayflowerbodynumbertag152.jpg" alt="Mayflower Body Number Tag" height="160px">
                     </a>
-                    <p><b>Author:</b> Russ Hoenig</p>
-                    <p><b>Synopsis:</b> Offer to stamp a blank FISHOLOW tag for members.</p>
-                    <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#152">Spring issue 2015 – № 152</a></p>
-                    <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/152.pdf#page=6" target="_blank">4</a></p>
-                </div>
-                <a href="{{ site.baseurl }}/documents/flowerpowers/152.pdf#page=6" target="_blank">
-                    <img src="mayflowerbodynumbertag152.jpg" alt="Mayflower Body Number Tag" height="160px">
-                </a>
-            </section>
-            <section class="panelWithRightJustifiedImage">
-                <div class="content">
+                </section>
+                <section class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <a href="{{ site.baseurl }}/documents/flowerpowers/157.pdf#page=9" target="_blank">
+                            <h3>Mayflower doors</h3>
+                        </a>
+                        <p><b>Author:</b> Harry Mulcahy (1032)</p>
+                        <p><b>Synopsis:</b> Repair of doors/frames.</p>
+                        <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#157">Winter/spring issue 2017 – № 157</a></p>
+                        <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/157.pdf#page=9" target="_blank">7</a></p>
+                    </div>
                     <a href="{{ site.baseurl }}/documents/flowerpowers/157.pdf#page=9" target="_blank">
-                        <h3>Mayflower doors</h3>
+                        <img src="mayflowerdoors157.jpg" alt="Mayflower Doors" height="160px">
                     </a>
-                    <p><b>Author:</b> Harry Mulcahy (1032)</p>
-                    <p><b>Synopsis:</b> Repair of doors/frames.</p>
-                    <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#157">Winter/spring issue 2017 – № 157</a></p>
-                    <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/157.pdf#page=9" target="_blank">7</a></p>
-                </div>
-                <a href="{{ site.baseurl }}/documents/flowerpowers/157.pdf#page=9" target="_blank">
-                    <img src="mayflowerdoors157.jpg" alt="Mayflower Doors" height="160px">
-                </a>
-            </section>
-            <section class="panelWithRightJustifiedImage">
-                <div class="content">
+                </section>
+                <section class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <a href="{{ site.baseurl }}/documents/flowerpowers/158.pdf#page=15" target="_blank">
+                            <h3>Mayflower window regulator channel</h3>
+                        </a>
+                        <p><b>Author:</b> Dave Gibbs</p>
+                        <p><b>Synopsis:</b> Replacement of window regulation channel.</p>
+                        <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#158">Summer issue 2017 – № 158</a></p>
+                        <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/158.pdf#page=15" target="_blank">13</a></p>
+                    </div>
                     <a href="{{ site.baseurl }}/documents/flowerpowers/158.pdf#page=15" target="_blank">
-                        <h3>Mayflower window regulator channel</h3>
+                        <img src="mayflowerwindowregulatorchannel158.jpg" alt="Mayflower Window Regulator Channel" height="160px">
                     </a>
-                    <p><b>Author:</b> Dave Gibbs</p>
-                    <p><b>Synopsis:</b> Replacement of window regulation channel.</p>
-                    <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#158">Summer issue 2017 – № 158</a></p>
-                    <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/158.pdf#page=15" target="_blank">13</a></p>
-                </div>
-                <a href="{{ site.baseurl }}/documents/flowerpowers/158.pdf#page=15" target="_blank">
-                    <img src="mayflowerwindowregulatorchannel158.jpg" alt="Mayflower Window Regulator Channel" height="160px">
-                </a>
+                </section>
             </section>
-        </section>
-        <section>
-            <h2 id="charging">Charging system</h2>
-            <section class="panelWithRightJustifiedImage">
-                <div class="content">
+            <section>
+                <h2 id="charging">Charging system</h2>
+                <section class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <a href="{{ site.baseurl }}/documents/flowerpowers/154.pdf#page=11" target="_blank">
+                            <h3>Fan belt</h3>
+                        </a>
+                        <p><b>Author:</b> Harry Mulcahy (1032)</p>
+                        <p><b>Synopsis:</b> Worn pullies, replacement of adjustment bracket.</p>
+                        <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#154">Winter/spring issue 2016 – № 154</a></p>
+                        <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/154.pdf#page=11" target="_blank">9</a></p>
+                    </div>
                     <a href="{{ site.baseurl }}/documents/flowerpowers/154.pdf#page=11" target="_blank">
-                        <h3>Fan belt</h3>
+                        <img src="fanbelt154.jpg" alt="Fan Belt" height="160px">
                     </a>
-                    <p><b>Author:</b> Harry Mulcahy (1032)</p>
-                    <p><b>Synopsis:</b> Worn pullies, replacement of adjustment bracket.</p>
-                    <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#154">Winter/spring issue 2016 – № 154</a></p>
-                    <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/154.pdf#page=11" target="_blank">9</a></p>
-                </div>
-                <a href="{{ site.baseurl }}/documents/flowerpowers/154.pdf#page=11" target="_blank">
-                    <img src="fanbelt154.jpg" alt="Fan Belt" height="160px">
-                </a>
+                </section>
             </section>
-        </section>
-        <section>
-            <h2 id="cooling">Cooling system</h2>
-            <section class="panelWithRightJustifiedImage">
-                <div class="content">
+            <section>
+                <h2 id="cooling">Cooling system</h2>
+                <section class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=12" target="_blank">
+                            <h3>AC 1572001 thermostat</h3>
+                        </a>
+                        <p><b>Author:</b> Paul Burgess (1200)</p>
+                        <p><b>Synopsis:</b> Availability of AC 1572001 thermostat.</p>
+                        <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#155">Summer issue 2016 – № 155</a></p>
+                        <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=12" target="_blank">10</a></p>
+                    </div>
                     <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=12" target="_blank">
-                        <h3>AC 1572001 thermostat</h3>
+                        <img src="ac1572001thermostat155.jpg" alt="AC 1572001 Thermostat" height="160px">
                     </a>
-                    <p><b>Author:</b> Paul Burgess (1200)</p>
-                    <p><b>Synopsis:</b> Availability of AC 1572001 thermostat.</p>
-                    <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#155">Summer issue 2016 – № 155</a></p>
-                    <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=12" target="_blank">10</a></p>
-                </div>
-                <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=12" target="_blank">
-                    <img src="ac1572001thermostat155.jpg" alt="AC 1572001 Thermostat" height="160px">
-                </a>
-            </section>
-            <section class="panelWithRightJustifiedImage">
-                <div class="content">
+                </section>
+                <section class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <a href="{{ site.baseurl }}/documents/flowerpowers/156.pdf#page=6" target="_blank">
+                            <h3>Thermostat</h3>
+                        </a>
+                        <p><b>Author:</b> John Leslie</p>
+                        <p><b>Synopsis:</b> Consequences of blocked vents in thermostat housing.</p>
+                        <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#156">Autumn issue 2016 – № 156</a></p>
+                        <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/156.pdf#page=6" target="_blank">4</a></p>
+                    </div>
                     <a href="{{ site.baseurl }}/documents/flowerpowers/156.pdf#page=6" target="_blank">
-                        <h3>Thermostat</h3>
+                        <img src="thermostat156.jpg" alt="Thermostat" height="160px">
                     </a>
-                    <p><b>Author:</b> John Leslie</p>
-                    <p><b>Synopsis:</b> Consequences of blocked vents in thermostat housing.</p>
-                    <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#156">Autumn issue 2016 – № 156</a></p>
-                    <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/156.pdf#page=6" target="_blank">4</a></p>
-                </div>
-                <a href="{{ site.baseurl }}/documents/flowerpowers/156.pdf#page=6" target="_blank">
-                    <img src="thermostat156.jpg" alt="Thermostat" height="160px">
-                </a>
-            </section>
-            <section class="panelWithRightJustifiedImage">
-                <div class="content">
+                </section>
+                <section class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <a href="{{ site.baseurl }}/documents/flowerpowers/157.pdf#page=9" target="_blank">
+                            <h3>Heater control valve</h3>
+                        </a>
+                        <p><b>Author:</b> Carl Stevenson (527)</p>
+                        <p><b>Synopsis:</b> Heater control valve repair.</p>
+                        <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#157">Winter/spring issue 2017 – № 157</a></p>
+                        <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/157.pdf#page=9" target="_blank">7</a></p>
+                    </div>
                     <a href="{{ site.baseurl }}/documents/flowerpowers/157.pdf#page=9" target="_blank">
-                        <h3>Heater control valve</h3>
+                        <img src="heatercontrolvalve157.jpg" alt="Heater Control Valve" height="160px">
                     </a>
-                    <p><b>Author:</b> Carl Stevenson (527)</p>
-                    <p><b>Synopsis:</b> Heater control valve repair.</p>
-                    <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#157">Winter/spring issue 2017 – № 157</a></p>
-                    <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/157.pdf#page=9" target="_blank">7</a></p>
-                </div>
-                <a href="{{ site.baseurl }}/documents/flowerpowers/157.pdf#page=9" target="_blank">
-                    <img src="heatercontrolvalve157.jpg" alt="Heater Control Valve" height="160px">
-                </a>
+                </section>
             </section>
-        </section>
-        <section>
-            <h2 id="electrical">Electrical system</h2>
-            <section class="panelWithRightJustifiedImage">
-                <div class="content">
+            <section>
+                <h2 id="electrical">Electrical system</h2>
+                <section class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <a href="{{ site.baseurl }}/documents/flowerpowers/154.pdf#page=18" target="_blank">
+                            <h3>Trafficators</h3>
+                        </a>
+                        <p><b>Author:</b> Michael Davidson (1031)</p>
+                        <p><b>Synopsis:</b> Addition of flashing indicator lights.</p>
+                        <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#154">Winter/spring issue 2016 – № 154</a></p>
+                        <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/154.pdf#page=18" target="_blank">16</a></p>
+                    </div>
                     <a href="{{ site.baseurl }}/documents/flowerpowers/154.pdf#page=18" target="_blank">
-                        <h3>Trafficators</h3>
+                        <img src="trafficators154.jpg" alt="Trafficators" height="160px">
                     </a>
-                    <p><b>Author:</b> Michael Davidson (1031)</p>
-                    <p><b>Synopsis:</b> Addition of flashing indicator lights.</p>
-                    <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#154">Winter/spring issue 2016 – № 154</a></p>
-                    <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/154.pdf#page=18" target="_blank">16</a></p>
-                </div>
-                <a href="{{ site.baseurl }}/documents/flowerpowers/154.pdf#page=18" target="_blank">
-                    <img src="trafficators154.jpg" alt="Trafficators" height="160px">
-                </a>
-            </section>
-            <section class="panelWithRightJustifiedImage">
-                <div class="content">
+                </section>
+                <section class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=8" target="_blank">
+                            <h3>Trafficators</h3>
+                        </a>
+                        <p><b>Author:</b> Paul Burgess (1200)</p>
+                        <p><b>Synopsis:</b> Addition of audible alarm to confirm trafficator deployment.</p>
+                        <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#155">Summer issue 2016 – № 155</a></p>
+                        <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=8" target="_blank">6</a></p>
+                    </div>
                     <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=8" target="_blank">
-                        <h3>Trafficators</h3>
+                        <img src="trafficators155.jpg" alt="Trafficators" height="160px">
                     </a>
-                    <p><b>Author:</b> Paul Burgess (1200)</p>
-                    <p><b>Synopsis:</b> Addition of audible alarm to confirm trafficator deployment.</p>
-                    <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#155">Summer issue 2016 – № 155</a></p>
-                    <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=8" target="_blank">6</a></p>
-                </div>
-                <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=8" target="_blank">
-                    <img src="trafficators155.jpg" alt="Trafficators" height="160px">
-                </a>
-            </section>
-            <section class="panelWithRightJustifiedImage">
-                <div class="content">
+                </section>
+                <section class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=13" target="_blank">
+                            <h3>Trafficators and indicators</h3>
+                        </a>
+                        <p><b>Author:</b> Paul Burgess (1200)</p>
+                        <p><b>Synopsis:</b> Addition of removable flashing indicator arrows.</p>
+                        <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#155">Summer issue 2016 – № 155</a></p>
+                        <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=13" target="_blank">11</a></p>
+                    </div>
                     <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=13" target="_blank">
-                        <h3>Trafficators and indicators</h3>
+                        <img src="trafficatorsandindicators155.jpg" alt="Trafficators and Indicators" height="160px">
                     </a>
-                    <p><b>Author:</b> Paul Burgess (1200)</p>
-                    <p><b>Synopsis:</b> Addition of removable flashing indicator arrows.</p>
-                    <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#155">Summer issue 2016 – № 155</a></p>
-                    <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=13" target="_blank">11</a></p>
-                </div>
-                <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=13" target="_blank">
-                    <img src="trafficatorsandindicators155.jpg" alt="Trafficators and Indicators" height="160px">
-                </a>
-            </section>
-            <section class="panelWithRightJustifiedImage">
-                <div class="content">
+                </section>
+                <section class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <a href="{{ site.baseurl }}/documents/flowerpowers/157.pdf#page=12" target="_blank">
+                            <h3>Horn brackets</h3>
+                        </a>
+                        <p><b>Author:</b> Bryan Stevens (1216)</p>
+                        <p><b>Synopsis:</b> Manufacture of horn brackets.</p>
+                        <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#157">Winter/spring issue 2017 – № 157</a></p>
+                        <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/157.pdf#page=12" target="_blank">10</a></p>
+                    </div>
                     <a href="{{ site.baseurl }}/documents/flowerpowers/157.pdf#page=12" target="_blank">
-                        <h3>Horn brackets</h3>
+                        <img src="hornbrackets157.jpg" alt="Horn Brackets" height="160px">
                     </a>
-                    <p><b>Author:</b> Bryan Stevens (1216)</p>
-                    <p><b>Synopsis:</b> Manufacture of horn brackets.</p>
-                    <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#157">Winter/spring issue 2017 – № 157</a></p>
-                    <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/157.pdf#page=12" target="_blank">10</a></p>
-                </div>
-                <a href="{{ site.baseurl }}/documents/flowerpowers/157.pdf#page=12" target="_blank">
-                    <img src="hornbrackets157.jpg" alt="Horn Brackets" height="160px">
-                </a>
+                </section>
             </section>
-        </section>
-        <section>
-            <h2 id="engine">Engine</h2>
-            <section class="panelWithRightJustifiedImage">
-                <div class="content">
+            <section>
+                <h2 id="engine">Engine</h2>
+                <section class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <a href="{{ site.baseurl }}/documents/flowerpowers/154.pdf#page=17" target="_blank">
+                            <h3>Engine mountings</h3>
+                        </a>
+                        <p><b>Author:</b> Harry Mulcahy (1032)</p>
+                        <p><b>Synopsis:</b> Replacement of engine mountings.</p>
+                        <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#154">Winter/spring issue 2016 – № 154</a></p>
+                        <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/154.pdf#page=17" target="_blank">15</a></p>
+                    </div>
                     <a href="{{ site.baseurl }}/documents/flowerpowers/154.pdf#page=17" target="_blank">
-                        <h3>Engine mountings</h3>
+                        <img src="enginemountings154.jpg" alt="Engine Mountings" height="160px">
                     </a>
-                    <p><b>Author:</b> Harry Mulcahy (1032)</p>
-                    <p><b>Synopsis:</b> Replacement of engine mountings.</p>
-                    <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#154">Winter/spring issue 2016 – № 154</a></p>
-                    <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/154.pdf#page=17" target="_blank">15</a></p>
-                </div>
-                <a href="{{ site.baseurl }}/documents/flowerpowers/154.pdf#page=17" target="_blank">
-                    <img src="enginemountings154.jpg" alt="Engine Mountings" height="160px">
-                </a>
-            </section>
-            <section class="panelWithRightJustifiedImage">
-                <div class="content">
+                </section>
+                <section class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <a href="{{ site.baseurl }}/documents/flowerpowers/147.pdf#page=4" target="_blank">
+                            <h3>Editorial (carburettor jets)</h3>
+                        </a>
+                        <p><b>Author:</b> Nico ten Wolde</p>
+                        <p><b>Synopsis:</b> Missing carburettor intake jets – a modification.</p>
+                        <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#147">Winter issue 2013 – № 147</a></p>
+                        <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/147.pdf#page=4" target="_blank">2</a></p>
+                    </div>
                     <a href="{{ site.baseurl }}/documents/flowerpowers/147.pdf#page=4" target="_blank">
-                        <h3>Editorial (carburettor jets)</h3>
+                        <img src="carburettorjets147.jpg" alt="Carburettor Jets" height="160px">
                     </a>
-                    <p><b>Author:</b> Nico ten Wolde</p>
-                    <p><b>Synopsis:</b> Missing carburettor intake jets – a modification.</p>
-                    <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#147">Winter issue 2013 – № 147</a></p>
-                    <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/147.pdf#page=4" target="_blank">2</a></p>
-                </div>
-                <a href="{{ site.baseurl }}/documents/flowerpowers/147.pdf#page=4" target="_blank">
-                    <img src="carburettorjets147.jpg" alt="Carburettor Jets" height="160px">
-                </a>
-            </section>
-            <section class="panelWithRightJustifiedImage">
-                <div class="content">
+                </section>
+                <section class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=15" target="_blank">
+                            <h3>Cylinder head remover</h3>
+                        </a>
+                        <p><b>Author:</b> (1985 reprint)</p>
+                        <p><b>Synopsis:</b> Making a tool to assist with cylinder head removal.</p>
+                        <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#155">Summer issue 2016 – № 155</a></p>
+                        <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=15" target="_blank">13</a></p>
+                    </div>
                     <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=15" target="_blank">
-                        <h3>Cylinder head remover</h3>
+                        <img src="cylinderheadremover155.jpg" alt="Cylinder Head Remover" height="160px">
                     </a>
-                    <p><b>Author:</b> (1985 reprint)</p>
-                    <p><b>Synopsis:</b> Making a tool to assist with cylinder head removal.</p>
-                    <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#155">Summer issue 2016 – № 155</a></p>
-                    <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=15" target="_blank">13</a></p>
-                </div>
-                <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=15" target="_blank">
-                    <img src="cylinderheadremover155.jpg" alt="Cylinder Head Remover" height="160px">
-                </a>
+                </section>
             </section>
-        </section>
-        <section>
-            <h2 id="ignition">Ignition system</h2>
-            <section class="panelWithRightJustifiedImage">
-                <div class="content">
+            <section>
+                <h2 id="ignition">Ignition system</h2>
+                <section class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=15" target="_blank">
+                            <h3>Electronic ignition</h3>
+                        </a>
+                        <p><b>Author:</b> Paul Burgess (1200)</p>
+                        <p><b>Synopsis:</b> Replacement of points with electronic ignition.</p>
+                        <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#155">Summer issue 2016 – № 155</a></p>
+                        <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=15" target="_blank">13</a></p>
+                    </div>
                     <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=15" target="_blank">
-                        <h3>Electronic ignition</h3>
+                        <img src="electronicignition155.jpg" alt="Electronic Ignition" height="160px">
                     </a>
-                    <p><b>Author:</b> Paul Burgess (1200)</p>
-                    <p><b>Synopsis:</b> Replacement of points with electronic ignition.</p>
-                    <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#155">Summer issue 2016 – № 155</a></p>
-                    <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=15" target="_blank">13</a></p>
-                </div>
-                <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=15" target="_blank">
-                    <img src="electronicignition155.jpg" alt="Electronic Ignition" height="160px">
-                </a>
-            </section>
-            <section class="panelWithRightJustifiedImage">
-                <div class="content">
+                </section>
+                <section class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <a href="{{ site.baseurl }}/documents/flowerpowers/156.pdf#page=15" target="_blank">
+                            <h3>Mayflower ignition</h3>
+                        </a>
+                        <p><b>Author:</b> Harry Mulcahy (1032)</p>
+                        <p><b>Synopsis:</b> Moving coil from cylinder head. Changing rotor arm.</p>
+                        <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#156">Autumn issue 2016 – № 156</a></p>
+                        <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/156.pdf#page=15" target="_blank">13</a></p>
+                    </div>
                     <a href="{{ site.baseurl }}/documents/flowerpowers/156.pdf#page=15" target="_blank">
-                        <h3>Mayflower ignition</h3>
+                        <img src="mayflowerignition156.jpg" alt="Mayflower Ignition" height="160px">
                     </a>
-                    <p><b>Author:</b> Harry Mulcahy (1032)</p>
-                    <p><b>Synopsis:</b> Moving coil from cylinder head. Changing rotor arm.</p>
-                    <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#156">Autumn issue 2016 – № 156</a></p>
-                    <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/156.pdf#page=15" target="_blank">13</a></p>
-                </div>
-                <a href="{{ site.baseurl }}/documents/flowerpowers/156.pdf#page=15" target="_blank">
-                    <img src="mayflowerignition156.jpg" alt="Mayflower Ignition" height="160px">
-                </a>
+                </section>
             </section>
-        </section>
-        <section>
-            <h2 id="instrumentation">Instrumentation</h2>
-            <section class="panelWithRightJustifiedImage">
-                <div class="content">
+            <section>
+                <h2 id="instrumentation">Instrumentation</h2>
+                <section class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=8" target="_blank">
+                            <h3>Oil pressure pipe repair</h3>
+                        </a>
+                        <p><b>Author:</b> Harry Mulcahy (1032)</p>
+                        <p><b>Synopsis:</b> Repair of oil pressure pipe.</p>
+                        <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#155">Summer issue 2016 – № 155</a></p>
+                        <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=8" target="_blank">6</a></p>
+                    </div>
                     <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=8" target="_blank">
-                        <h3>Oil pressure pipe repair</h3>
+                        <img src="oilpressurepiperepair155.jpg" alt="Oil Pressure Pipe Repair" height="160px">
                     </a>
-                    <p><b>Author:</b> Harry Mulcahy (1032)</p>
-                    <p><b>Synopsis:</b> Repair of oil pressure pipe.</p>
-                    <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#155">Summer issue 2016 – № 155</a></p>
-                    <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=8" target="_blank">6</a></p>
-                </div>
-                <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=8" target="_blank">
-                    <img src="oilpressurepiperepair155.jpg" alt="Oil Pressure Pipe Repair" height="160px">
-                </a>
-            </section>
-            <section class="panelWithRightJustifiedImage">
-                <div class="content">
+                </section>
+                <section class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <a href="{{ site.baseurl }}/documents/flowerpowers/157.pdf#page=17" target="_blank">
+                            <h3>Replacing the dashboard control knobs</h3>
+                        </a>
+                        <p><b>Author:</b> Michael Hudd (119)</p>
+                        <p><b>Synopsis:</b> Removing control knobs and fitting new ones.</p>
+                        <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#157">Winter/spring issue 2017 – № 157</a></p>
+                        <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/157.pdf#page=17" target="_blank">15-16</a></p>
+                    </div>
                     <a href="{{ site.baseurl }}/documents/flowerpowers/157.pdf#page=17" target="_blank">
-                        <h3>Replacing the dashboard control knobs</h3>
+                        <img src="replacingthedashboardcontrolknobs157.jpg" alt="Replacing the Dashboard Control Knobs" height="160px">
                     </a>
-                    <p><b>Author:</b> Michael Hudd (119)</p>
-                    <p><b>Synopsis:</b> Removing control knobs and fitting new ones.</p>
-                    <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#157">Winter/spring issue 2017 – № 157</a></p>
-                    <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/157.pdf#page=17" target="_blank">15-16</a></p>
-                </div>
-                <a href="{{ site.baseurl }}/documents/flowerpowers/157.pdf#page=17" target="_blank">
-                    <img src="replacingthedashboardcontrolknobs157.jpg" alt="Replacing the Dashboard Control Knobs" height="160px">
-                </a>
+                </section>
             </section>
-        </section>
-        <section>
-            <h2 id="rubberseals">Rubber seals</h2>
-            <section class="panelWithRightJustifiedImage">
-                <div class="content">
+            <section>
+                <h2 id="rubberseals">Rubber seals</h2>
+                <section class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <a href="{{ site.baseurl }}/documents/flowerpowers/154.pdf#page=7" target="_blank">
+                            <h3>Door seals and other moulding projects</h3>
+                        </a>
+                        <p><b>Author:</b> Russ Hoenig</p>
+                        <p><b>Synopsis:</b> Drawings for lower door seal and vertical seal at rear of door.</p>
+                        <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#154">Winter/spring issue 2016 – № 154</a></p>
+                        <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/154.pdf#page=7" target="_blank">5</a></p>
+                    </div>
                     <a href="{{ site.baseurl }}/documents/flowerpowers/154.pdf#page=7" target="_blank">
-                        <h3>Door seals and other moulding projects</h3>
+                        <img src="doorsealsandothermouldingprojects154.jpg" alt="Door Seals and Other Moulding Projects" height="160px">
                     </a>
-                    <p><b>Author:</b> Russ Hoenig</p>
-                    <p><b>Synopsis:</b> Drawings for lower door seal and vertical seal at rear of door.</p>
-                    <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#154">Winter/spring issue 2016 – № 154</a></p>
-                    <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/154.pdf#page=7" target="_blank">5</a></p>
-                </div>
-                <a href="{{ site.baseurl }}/documents/flowerpowers/154.pdf#page=7" target="_blank">
-                    <img src="doorsealsandothermouldingprojects154.jpg" alt="Door Seals and Other Moulding Projects" height="160px">
-                </a>
-            </section>
-            <section class="panelWithRightJustifiedImage">
-                <div class="content">
+                </section>
+                <section class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=12" target="_blank">
+                            <h3>Cowl/bonnet rubber seal</h3>
+                        </a>
+                        <p><b>Author:</b> Russ Hoenig</p>
+                        <p><b>Synopsis:</b> Drawing of seal.</p>
+                        <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#155">Summer issue 2016 – № 155</a></p>
+                        <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=12" target="_blank">10</a></p>
+                    </div>
                     <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=12" target="_blank">
-                        <h3>Cowl/bonnet rubber seal</h3>
+                        <img src="cowlbonnetrubberseal155.jpg" alt="Cowl/Bonnet Rubber Seal" height="160px">
                     </a>
-                    <p><b>Author:</b> Russ Hoenig</p>
-                    <p><b>Synopsis:</b> Drawing of seal.</p>
-                    <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#155">Summer issue 2016 – № 155</a></p>
-                    <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=12" target="_blank">10</a></p>
-                </div>
-                <a href="{{ site.baseurl }}/documents/flowerpowers/155.pdf#page=12" target="_blank">
-                    <img src="cowlbonnetrubberseal155.jpg" alt="Cowl/Bonnet Rubber Seal" height="160px">
-                </a>
-            </section>
-            <section class="panelWithRightJustifiedImage">
-                <div class="content">
+                </section>
+                <section class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <a href="{{ site.baseurl }}/documents/flowerpowers/153.pdf#page=15" target="_blank">
+                            <h3>Door and bonnet seals</h3>
+                        </a>
+                        <p><b>Author:</b> Russ Hoenig</p>
+                        <p><b>Synopsis:</b> Suggestions of design and availabliity of door and bonnet seals.</p>
+                        <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#153">Autumn issue 2015 – № 153</a></p>
+                        <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/153.pdf#page=15" target="_blank">13</a></p>
+                    </div>
                     <a href="{{ site.baseurl }}/documents/flowerpowers/153.pdf#page=15" target="_blank">
-                        <h3>Door and bonnet seals</h3>
+                        <img src="doorandbonnetseals153.jpg" alt="Door and Bonnet Seals" height="160px">
                     </a>
-                    <p><b>Author:</b> Russ Hoenig</p>
-                    <p><b>Synopsis:</b> Suggestions of design and availabliity of door and bonnet seals.</p>
-                    <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#153">Autumn issue 2015 – № 153</a></p>
-                    <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/153.pdf#page=15" target="_blank">13</a></p>
-                </div>
-                <a href="{{ site.baseurl }}/documents/flowerpowers/153.pdf#page=15" target="_blank">
-                    <img src="doorandbonnetseals153.jpg" alt="Door and Bonnet Seals" height="160px">
-                </a>
+                </section>
             </section>
-        </section>
-        <section>
-            <h2 id="runninggear">Running gear</h2>
-            <section class="panelWithRightJustifiedImage">
-                <div class="content">
+            <section>
+                <h2 id="runninggear">Running gear</h2>
+                <section class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <a href="{{ site.baseurl }}/documents/flowerpowers/149.pdf#page=12" target="_blank">
+                            <h3>Tyres</h3>
+                        </a>
+                        <p><b>Author:</b> James Fairchild</p>
+                        <p><b>Synopsis:</b> Legal and other useful advice on condition of tyres.</p>
+                        <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#149">Summer issue 2014 – № 149</a></p>
+                        <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/149.pdf#page=12" target="_blank">10-11</a></p>
+                    </div>
                     <a href="{{ site.baseurl }}/documents/flowerpowers/149.pdf#page=12" target="_blank">
-                        <h3>Tyres</h3>
+                        <img src="tyres149.jpg" alt="Tyres" height="160px">
                     </a>
-                    <p><b>Author:</b> James Fairchild</p>
-                    <p><b>Synopsis:</b> Legal and other useful advice on condition of tyres.</p>
-                    <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#149">Summer issue 2014 – № 149</a></p>
-                    <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/149.pdf#page=12" target="_blank">10-11</a></p>
-                </div>
-                <a href="{{ site.baseurl }}/documents/flowerpowers/149.pdf#page=12" target="_blank">
-                    <img src="tyres149.jpg" alt="Tyres" height="160px">
-                </a>
-            </section>
-            <section class="panelWithRightJustifiedImage">
-                <div class="content">
+                </section>
+                <section class="panelWithRightJustifiedImage">
+                    <div class="content">
+                        <a href="{{ site.baseurl }}/documents/flowerpowers/152.pdf#page=12" target="_blank">
+                            <h3>Overhauling the front suspension</h3>
+                        </a>
+                        <p><b>Author:</b> (Unknown)</p>
+                        <p><b>Synopsis:</b> Overhauling the front suspension.</p>
+                        <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#152">Spring issue 2015 – № 152</a></p>
+                        <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/152.pdf#page=12" target="_blank">10-12</a></p>
+                    </div>
                     <a href="{{ site.baseurl }}/documents/flowerpowers/152.pdf#page=12" target="_blank">
-                        <h3>Overhauling the front suspension</h3>
+                        <img src="overhaulingthefrontsuspension152.jpg" alt="Overhauling the Front Suspension" height="160px">
                     </a>
-                    <p><b>Author:</b> (Unknown)</p>
-                    <p><b>Synopsis:</b> Overhauling the front suspension.</p>
-                    <p><b>Featured in:</b> <a href="{{ site.baseurl }}/documents/flowerpowers/flowerpowers.html#152">Spring issue 2015 – № 152</a></p>
-                    <p><b>Page(s):</b> <a href="{{ site.baseurl }}/documents/flowerpowers/152.pdf#page=12" target="_blank">10-12</a></p>
-                </div>
-                <a href="{{ site.baseurl }}/documents/flowerpowers/152.pdf#page=12" target="_blank">
-                    <img src="overhaulingthefrontsuspension152.jpg" alt="Overhauling the Front Suspension" height="160px">
-                </a>
+                </section>
             </section>
-        </section>
+        </div>
     </article>
     <aside>
         <h2>Skip to section</h2>

--- a/documents/flowerpowers/flowerpowers.html
+++ b/documents/flowerpowers/flowerpowers.html
@@ -6,248 +6,259 @@ title: Flower Power Archive
 <link href="flowerpowers.css" rel="stylesheet" type="text/css">
 <main>
     <article>
-        <h1>Flower Power Archive</h1>
-        <p>For the uninitiated, <i>Flower Power</i> is the periodical of the Triumph Mayflower Club. It is open for all members to contribute content to and is another forum for communication between members. This section aspires to include all issues ever published by the TMC. To read more about <a href="{{ site.baseurl }}/history/flowerpower/flowerpower.html">the history of our club’s magazine</a>, visit the history section of the website.</p>
-        <section>
-            <h2>Featured technical articles</h2>
-            <p>Over the years, Flower Power has featured a number of technical articles – mostly written by club members based on their own experience – pertaining to the maintenance of the Mayflower. The link below will take you to a list of all such articles currently available on the website; the eventual goal is for all articles ever to be published in Flower Power since its inception to be available online in an accessible format, so that it forms a comprehensive handbook containing the club’s collective expertise.</p>
-            <a href="articles/articles.html">
-                <h3>Technical article list</h3>
-            </a>
-        </section>
-        <section>
-            <h2>Past issue downloads</h2>
-            <p>To view the issue in your browser, simply click the issue name heading or either of the thumbnail images which will open a new browser tab to the appropriate page. Alternatively, click the download link to save a PDF copy to your computer.</p>
+        <ol id="breadcrumb">
+            <li>
+                <a href="{{ site.baseurl }}/index.html">Home</a>
+            </li>
+            <li>
+                <a href="{{ site.baseurl }}/documents/documents.html">Documents</a>
+            </li>
+            <li>Flower Power Archive</li>
+        </ol>
+        <div id="content">
+            <h1>Flower Power Archive</h1>
+            <p>For the uninitiated, <i>Flower Power</i> is the periodical of the Triumph Mayflower Club. It is open for all members to contribute content to and is another forum for communication between members. This section aspires to include all issues ever published by the TMC. To read more about <a href="{{ site.baseurl }}/history/flowerpower/flowerpower.html">the history of our club’s magazine</a>, visit the history section of the website.</p>
             <section>
-                <a href="158.pdf" target="_blank">
-                    <h3 id="158">Summer issue 2017 – № 158</h3>
+                <h2>Featured technical articles</h2>
+                <p>Over the years, Flower Power has featured a number of technical articles – mostly written by club members based on their own experience – pertaining to the maintenance of the Mayflower. The link below will take you to a list of all such articles currently available on the website; the eventual goal is for all articles ever to be published in Flower Power since its inception to be available online in an accessible format, so that it forms a comprehensive handbook containing the club’s collective expertise.</p>
+                <a href="articles/articles.html">
+                    <h3>Technical article list</h3>
                 </a>
-                <a href="158.pdf" download="Flower Power – Issue 158.pdf">Download issue 158 as a PDF (23.4 MB)</a>
-                <div class="issuePreview">
-                    <div class="frontCover">
-                        <h4>Front cover</h4>
-                        <a href="158.pdf#page=1" target="_blank">
-                            <img src="158front.jpg" alt="Issue 158 Front Cover">
-                        </a>
-                    </div>
-                    <div class="contentsPage">
-                        <h4>Contents page</h4>
-                        <a href="158.pdf#page=3" target="_blank">
-                            <img src="158contents.jpg" alt="Issue 158 Contents Page">
-                        </a>
-                    </div>
-                </div>
             </section>
             <section>
-                <a href="157.pdf" target="_blank">
-                    <h3 id="157">Winter/spring issue 2017 – № 157</h3>
-                </a>
-                <a href="157.pdf" download="Flower Power – Issue 157.pdf">Download issue 157 as a PDF (23.0 MB)</a>
-                <div class="issuePreview">
-                    <div class="frontCover">
-                        <h4>Front cover</h4>
-                        <a href="157.pdf#page=1" target="_blank">
-                            <img src="157front.jpg" alt="Issue 157 Front Cover">
-                        </a>
-                    </div>
-                    <div class="contentsPage">
-                        <h4>Contents page</h4>
-                        <a href="157.pdf#page=3" target="_blank">
-                            <img src="157contents.jpg" alt="Issue 157 Contents Page">
-                        </a>
-                    </div>
-                </div>
-            </section>
-            <section>
-                <a href="156.pdf" target="_blank">
-                    <h3 id="156">Autumn issue 2016 – № 156</h3>
-                </a>
-                <a href="156.pdf" download="Flower Power – Issue 156.pdf">Download issue 156 as a PDF (22.4 MB)</a>
-                <div class="issuePreview">
-                    <div class="frontCover">
-                        <h4>Front cover</h4>
-                        <a href="156.pdf#page=1" target="_blank">
-                            <img src="156front.jpg" alt="Issue 156 Front Cover">
-                        </a>
-                    </div>
-                    <div class="contentsPage">
-                        <h4>Contents page</h4>
-                        <a href="156.pdf#page=3" target="_blank">
-                            <img src="156contents.jpg" alt="Issue 156 Contents Page">
-                        </a>
-                    </div>
-                </div>
-            </section>
-            <section>
-                <a href="155.pdf" target="_blank">
-                    <h3 id="155">Summer issue 2016 – № 155</h3>
-                </a>
-                <a href="155.pdf" download="Flower Power – Issue 155.pdf">Download issue 155 as a PDF (22.9 MB)</a>
-                <div class="issuePreview">
-                    <div class="frontCover">
-                        <h4>Front cover</h4>
-                        <a href="155.pdf#page=1" target="_blank">
-                            <img src="155front.jpg" alt="Issue 155 Front Cover">
-                        </a>
-                    </div>
-                    <div class="contentsPage">
-                        <h4>Contents page</h4>
-                        <a href="155.pdf#page=3" target="_blank">
-                            <img src="155contents.jpg" alt="Issue 155 Contents Page">
-                        </a>
-                    </div>
-                </div>
-            </section>
-            <section>
-                <a href="154.pdf" target="_blank">
-                    <h3 id="154">Winter/spring issue 2016 – № 154</h3>
-                </a>
-                <a href="154.pdf" download="Flower Power – Issue 154.pdf">Download issue 154 as a PDF (23.0 MB)</a>
-                <div class="issuePreview">
-                    <div class="frontCover">
-                        <h4>Front cover</h4>
-                        <a href="154.pdf#page=1" target="_blank">
-                            <img src="154front.jpg" alt="Issue 154 Front Cover">
-                        </a>
-                    </div>
-                    <div class="contentsPage">
-                        <h4>Contents page</h4>
-                        <a href="154.pdf#page=3" target="_blank">
-                            <img src="154contents.jpg" alt="Issue 154 Contents Page">
-                        </a>
-                    </div>
-                </div>
-            </section>
-            <section>
-                <a href="153.pdf" target="_blank">
-                    <h3 id="153">Autumn issue 2015 – № 153</h3>
-                </a>
-                <a href="153.pdf" download="Flower Power – Issue 153.pdf">Download issue 153 as a PDF (22.2 MB)</a>
-                <div class="issuePreview">
-                    <div class="frontCover">
-                        <h4>Front cover</h4>
-                        <a href="153.pdf#page=1" target="_blank">
-                            <img src="153front.jpg" alt="Issue 153 Front Cover">
-                        </a>
-                    </div>
-                    <div class="contentsPage">
-                        <h4>Contents page</h4>
-                        <a href="153.pdf#page=3" target="_blank">
-                            <img src="153contents.jpg" alt="Issue 153 Contents Page">
-                        </a>
-                    </div>
-                </div>
-            </section>
-            <section>
-                <a href="152.pdf" target="_blank">
-                    <h3 id="152">Spring issue 2015 – № 152</h3>
-                </a>
-                <a href="152.pdf" download="Flower Power – Issue 152.pdf">Download issue 152 as a PDF (17.9 MB)</a>
-                <div class="issuePreview">
-                    <div class="frontCover">
-                        <h4>Front cover</h4>
-                        <a href="152.pdf#page=1" target="_blank">
-                            <img src="152front.jpg" alt="Issue 152 Front Cover">
-                        </a>
-                    </div>
-                    <div class="contentsPage">
-                        <h4>Contents page</h4>
-                        <a href="152.pdf#page=3" target="_blank">
-                            <img src="152contents.jpg" alt="Issue 152 Contents Page">
-                        </a>
-                    </div>
-                </div>
-            </section>
-            <section>
-                <h3 id="151">(Unavailable) – № 151</h3>
-                <p>We’re currently missing issue 151 from our records! If you have a copy of this issue and would be willing to post it to us for scanning (we’d post it straight back afterwards), please get in-touch with our website editor, Rob Davies.</p>
+                <h2>Past issue downloads</h2>
+                <p>To view the issue in your browser, simply click the issue name heading or either of the thumbnail images which will open a new browser tab to the appropriate page. Alternatively, click the download link to save a PDF copy to your computer.</p>
                 <section>
-                    <h4>Rob Davies</h4>
-                    <p>Phone: <a href="tel:+441291623388">(01291) 623388</a></p>
-                    <p>Email: <a href="mailto:robertldavies@btinternet.com?subject=Flower%20Power%20Issue%20151">robertldavies@btinternet.com</a></p>
+                    <a href="158.pdf" target="_blank">
+                        <h3 id="158">Summer issue 2017 – № 158</h3>
+                    </a>
+                    <a href="158.pdf" download="Flower Power – Issue 158.pdf">Download issue 158 as a PDF (23.4 MB)</a>
+                    <div class="issuePreview">
+                        <div class="frontCover">
+                            <h4>Front cover</h4>
+                            <a href="158.pdf#page=1" target="_blank">
+                                <img src="158front.jpg" alt="Issue 158 Front Cover">
+                            </a>
+                        </div>
+                        <div class="contentsPage">
+                            <h4>Contents page</h4>
+                            <a href="158.pdf#page=3" target="_blank">
+                                <img src="158contents.jpg" alt="Issue 158 Contents Page">
+                            </a>
+                        </div>
+                    </div>
+                </section>
+                <section>
+                    <a href="157.pdf" target="_blank">
+                        <h3 id="157">Winter/spring issue 2017 – № 157</h3>
+                    </a>
+                    <a href="157.pdf" download="Flower Power – Issue 157.pdf">Download issue 157 as a PDF (23.0 MB)</a>
+                    <div class="issuePreview">
+                        <div class="frontCover">
+                            <h4>Front cover</h4>
+                            <a href="157.pdf#page=1" target="_blank">
+                                <img src="157front.jpg" alt="Issue 157 Front Cover">
+                            </a>
+                        </div>
+                        <div class="contentsPage">
+                            <h4>Contents page</h4>
+                            <a href="157.pdf#page=3" target="_blank">
+                                <img src="157contents.jpg" alt="Issue 157 Contents Page">
+                            </a>
+                        </div>
+                    </div>
+                </section>
+                <section>
+                    <a href="156.pdf" target="_blank">
+                        <h3 id="156">Autumn issue 2016 – № 156</h3>
+                    </a>
+                    <a href="156.pdf" download="Flower Power – Issue 156.pdf">Download issue 156 as a PDF (22.4 MB)</a>
+                    <div class="issuePreview">
+                        <div class="frontCover">
+                            <h4>Front cover</h4>
+                            <a href="156.pdf#page=1" target="_blank">
+                                <img src="156front.jpg" alt="Issue 156 Front Cover">
+                            </a>
+                        </div>
+                        <div class="contentsPage">
+                            <h4>Contents page</h4>
+                            <a href="156.pdf#page=3" target="_blank">
+                                <img src="156contents.jpg" alt="Issue 156 Contents Page">
+                            </a>
+                        </div>
+                    </div>
+                </section>
+                <section>
+                    <a href="155.pdf" target="_blank">
+                        <h3 id="155">Summer issue 2016 – № 155</h3>
+                    </a>
+                    <a href="155.pdf" download="Flower Power – Issue 155.pdf">Download issue 155 as a PDF (22.9 MB)</a>
+                    <div class="issuePreview">
+                        <div class="frontCover">
+                            <h4>Front cover</h4>
+                            <a href="155.pdf#page=1" target="_blank">
+                                <img src="155front.jpg" alt="Issue 155 Front Cover">
+                            </a>
+                        </div>
+                        <div class="contentsPage">
+                            <h4>Contents page</h4>
+                            <a href="155.pdf#page=3" target="_blank">
+                                <img src="155contents.jpg" alt="Issue 155 Contents Page">
+                            </a>
+                        </div>
+                    </div>
+                </section>
+                <section>
+                    <a href="154.pdf" target="_blank">
+                        <h3 id="154">Winter/spring issue 2016 – № 154</h3>
+                    </a>
+                    <a href="154.pdf" download="Flower Power – Issue 154.pdf">Download issue 154 as a PDF (23.0 MB)</a>
+                    <div class="issuePreview">
+                        <div class="frontCover">
+                            <h4>Front cover</h4>
+                            <a href="154.pdf#page=1" target="_blank">
+                                <img src="154front.jpg" alt="Issue 154 Front Cover">
+                            </a>
+                        </div>
+                        <div class="contentsPage">
+                            <h4>Contents page</h4>
+                            <a href="154.pdf#page=3" target="_blank">
+                                <img src="154contents.jpg" alt="Issue 154 Contents Page">
+                            </a>
+                        </div>
+                    </div>
+                </section>
+                <section>
+                    <a href="153.pdf" target="_blank">
+                        <h3 id="153">Autumn issue 2015 – № 153</h3>
+                    </a>
+                    <a href="153.pdf" download="Flower Power – Issue 153.pdf">Download issue 153 as a PDF (22.2 MB)</a>
+                    <div class="issuePreview">
+                        <div class="frontCover">
+                            <h4>Front cover</h4>
+                            <a href="153.pdf#page=1" target="_blank">
+                                <img src="153front.jpg" alt="Issue 153 Front Cover">
+                            </a>
+                        </div>
+                        <div class="contentsPage">
+                            <h4>Contents page</h4>
+                            <a href="153.pdf#page=3" target="_blank">
+                                <img src="153contents.jpg" alt="Issue 153 Contents Page">
+                            </a>
+                        </div>
+                    </div>
+                </section>
+                <section>
+                    <a href="152.pdf" target="_blank">
+                        <h3 id="152">Spring issue 2015 – № 152</h3>
+                    </a>
+                    <a href="152.pdf" download="Flower Power – Issue 152.pdf">Download issue 152 as a PDF (17.9 MB)</a>
+                    <div class="issuePreview">
+                        <div class="frontCover">
+                            <h4>Front cover</h4>
+                            <a href="152.pdf#page=1" target="_blank">
+                                <img src="152front.jpg" alt="Issue 152 Front Cover">
+                            </a>
+                        </div>
+                        <div class="contentsPage">
+                            <h4>Contents page</h4>
+                            <a href="152.pdf#page=3" target="_blank">
+                                <img src="152contents.jpg" alt="Issue 152 Contents Page">
+                            </a>
+                        </div>
+                    </div>
+                </section>
+                <section>
+                    <h3 id="151">(Unavailable) – № 151</h3>
+                    <p>We’re currently missing issue 151 from our records! If you have a copy of this issue and would be willing to post it to us for scanning (we’d post it straight back afterwards), please get in-touch with our website editor, Rob Davies.</p>
+                    <section>
+                        <h4>Rob Davies</h4>
+                        <p>Phone: <a href="tel:+441291623388">(01291) 623388</a></p>
+                        <p>Email: <a href="mailto:robertldavies@btinternet.com?subject=Flower%20Power%20Issue%20151">robertldavies@btinternet.com</a></p>
+                    </section>
+                </section>
+                <section>
+                    <a href="150.pdf" target="_blank">
+                        <h3 id="150">Autumn issue 2014 – № 150</h3>
+                    </a>
+                    <a href="150.pdf" download="Flower Power – Issue 150.pdf">Download issue 150 as a PDF (22.0 MB)</a>
+                    <div class="issuePreview">
+                        <div class="frontCover">
+                            <h4>Front cover</h4>
+                            <a href="150.pdf#page=1" target="_blank">
+                                <img src="150front.jpg" alt="Issue 150 Front Cover">
+                            </a>
+                        </div>
+                        <div class="contentsPage">
+                            <h4>Contents page</h4>
+                            <a href="150.pdf#page=3" target="_blank">
+                                <img src="150contents.jpg" alt="Issue 150 Contents Page">
+                            </a>
+                        </div>
+                    </div>
+                </section>
+                <section>
+                    <a href="149.pdf" target="_blank">
+                        <h3 id="149">Summer issue 2014 – № 149</h3>
+                    </a>
+                    <a href="149.pdf" download="Flower Power – Issue 149.pdf">Download issue 149 as a PDF (25.5 MB)</a>
+                    <div class="issuePreview">
+                        <div class="frontCover">
+                            <h4>Front cover</h4>
+                            <a href="149.pdf#page=1" target="_blank">
+                                <img src="149front.jpg" alt="Issue 149 Front Cover">
+                            </a>
+                        </div>
+                        <div class="contentsPage">
+                            <h4>Contents page</h4>
+                            <a href="149.pdf#page=3" target="_blank">
+                                <img src="149contents.jpg" alt="Issue 149 Contents Page">
+                            </a>
+                        </div>
+                    </div>
+                </section>
+                <section>
+                    <a href="148.pdf" target="_blank">
+                        <h3 id="148">Spring issue 2014 – № 148</h3>
+                    </a>
+                    <a href="148.pdf" download="Flower Power – Issue 148.pdf">Download issue 148 as a PDF (20.3 MB)</a>
+                    <div class="issuePreview">
+                        <div class="frontCover">
+                            <h4>Front cover</h4>
+                            <a href="148.pdf#page=1" target="_blank">
+                                <img src="148front.jpg" alt="Issue 148 Front Cover">
+                            </a>
+                        </div>
+                        <div class="contentsPage">
+                            <h4>Contents page</h4>
+                            <a href="148.pdf#page=3" target="_blank">
+                                <img src="148contents.jpg" alt="Issue 148 Contents Page">
+                            </a>
+                        </div>
+                    </div>
+                </section>
+                <section>
+                    <a href="147.pdf" target="_blank">
+                        <h3 id="147">Winter issue 2013 – № 147</h3>
+                    </a>
+                    <a href="147.pdf" download="Flower Power – Issue 147.pdf">Download issue 147 as a PDF (22.3 MB)</a>
+                    <div class="issuePreview">
+                        <div class="frontCover">
+                            <h4>Front cover</h4>
+                            <a href="147.pdf#page=1" target="_blank">
+                                <img src="147front.jpg" alt="Issue 147 Front Cover">
+                            </a>
+                        </div>
+                        <div class="contentsPage">
+                            <h4>Contents page</h4>
+                            <a href="147.pdf#page=3" target="_blank">
+                                <img src="147contents.jpg" alt="Issue 147 Contents Page">
+                            </a>
+                        </div>
+                    </div>
                 </section>
             </section>
-            <section>
-                <a href="150.pdf" target="_blank">
-                    <h3 id="150">Autumn issue 2014 – № 150</h3>
-                </a>
-                <a href="150.pdf" download="Flower Power – Issue 150.pdf">Download issue 150 as a PDF (22.0 MB)</a>
-                <div class="issuePreview">
-                    <div class="frontCover">
-                        <h4>Front cover</h4>
-                        <a href="150.pdf#page=1" target="_blank">
-                            <img src="150front.jpg" alt="Issue 150 Front Cover">
-                        </a>
-                    </div>
-                    <div class="contentsPage">
-                        <h4>Contents page</h4>
-                        <a href="150.pdf#page=3" target="_blank">
-                            <img src="150contents.jpg" alt="Issue 150 Contents Page">
-                        </a>
-                    </div>
-                </div>
-            </section>
-            <section>
-                <a href="149.pdf" target="_blank">
-                    <h3 id="149">Summer issue 2014 – № 149</h3>
-                </a>
-                <a href="149.pdf" download="Flower Power – Issue 149.pdf">Download issue 149 as a PDF (25.5 MB)</a>
-                <div class="issuePreview">
-                    <div class="frontCover">
-                        <h4>Front cover</h4>
-                        <a href="149.pdf#page=1" target="_blank">
-                            <img src="149front.jpg" alt="Issue 149 Front Cover">
-                        </a>
-                    </div>
-                    <div class="contentsPage">
-                        <h4>Contents page</h4>
-                        <a href="149.pdf#page=3" target="_blank">
-                            <img src="149contents.jpg" alt="Issue 149 Contents Page">
-                        </a>
-                    </div>
-                </div>
-            </section>
-            <section>
-                <a href="148.pdf" target="_blank">
-                    <h3 id="148">Spring issue 2014 – № 148</h3>
-                </a>
-                <a href="148.pdf" download="Flower Power – Issue 148.pdf">Download issue 148 as a PDF (20.3 MB)</a>
-                <div class="issuePreview">
-                    <div class="frontCover">
-                        <h4>Front cover</h4>
-                        <a href="148.pdf#page=1" target="_blank">
-                            <img src="148front.jpg" alt="Issue 148 Front Cover">
-                        </a>
-                    </div>
-                    <div class="contentsPage">
-                        <h4>Contents page</h4>
-                        <a href="148.pdf#page=3" target="_blank">
-                            <img src="148contents.jpg" alt="Issue 148 Contents Page">
-                        </a>
-                    </div>
-                </div>
-            </section>
-            <section>
-                <a href="147.pdf" target="_blank">
-                    <h3 id="147">Winter issue 2013 – № 147</h3>
-                </a>
-                <a href="147.pdf" download="Flower Power – Issue 147.pdf">Download issue 147 as a PDF (22.3 MB)</a>
-                <div class="issuePreview">
-                    <div class="frontCover">
-                        <h4>Front cover</h4>
-                        <a href="147.pdf#page=1" target="_blank">
-                            <img src="147front.jpg" alt="Issue 147 Front Cover">
-                        </a>
-                    </div>
-                    <div class="contentsPage">
-                        <h4>Contents page</h4>
-                        <a href="147.pdf#page=3" target="_blank">
-                            <img src="147contents.jpg" alt="Issue 147 Contents Page">
-                        </a>
-                    </div>
-                </div>
-            </section>
-        </section>
+        </div>
     </article>
     <aside>
         <section>

--- a/documents/technical/technical.html
+++ b/documents/technical/technical.html
@@ -5,20 +5,31 @@ title: Technical Documentation
 
 <main>
     <article>
-        <h1>Technical Documentation</h1>
-        <p>Page description...</p>
-        <section>
-            <h2>Mayflower service instruction manual</h2>
-            <h3>First edition – April 1951, The Standard Motor Company Ltd</h3>
-            <a href="servicemanual.pdf" download="Mayflower Service Instruction Manual.pdf">Download the service manual as a PDF (10.2 MB)</a>
-        </section>
-        <section>
-            <h2>Technical articles featured in Flower Power</h2>
-            <p>Over the years, Flower Power has featured a number of technical articles – mostly written by club members based on their own experience – pertaining to the maintenance of the Mayflower. The link below will take you to a list of all such articles currently available on the website; the eventual goal is for all articles ever to be published in Flower Power since its inception to be available online in an accessible format, so that it forms a comprehensive handbook containing the club’s collective expertise.</p>
-            <a href="{{ site.baseurl }}/documents/flowerpowers/articles/articles.html">
-                <h3>Technical article list</h3>
-            </a>
-        </section>
+        <ol id="breadcrumb">
+            <li>
+                <a href="{{ site.baseurl }}/index.html">Home</a>
+            </li>
+            <li>
+                <a href="{{ site.baseurl }}/documents/documents.html">Documents</a>
+            </li>
+            <li>Technical Documentation</li>
+        </ol>
+        <div id="content">
+            <h1>Technical Documentation</h1>
+            <p>Page description...</p>
+            <section>
+                <h2>Mayflower service instruction manual</h2>
+                <h3>First edition – April 1951, The Standard Motor Company Ltd</h3>
+                <a href="servicemanual.pdf" download="Mayflower Service Instruction Manual.pdf">Download the service manual as a PDF (10.2 MB)</a>
+            </section>
+            <section>
+                <h2>Technical articles featured in Flower Power</h2>
+                <p>Over the years, Flower Power has featured a number of technical articles – mostly written by club members based on their own experience – pertaining to the maintenance of the Mayflower. The link below will take you to a list of all such articles currently available on the website; the eventual goal is for all articles ever to be published in Flower Power since its inception to be available online in an accessible format, so that it forms a comprehensive handbook containing the club’s collective expertise.</p>
+                <a href="{{ site.baseurl }}/documents/flowerpowers/articles/articles.html">
+                    <h3>Technical article list</h3>
+                </a>
+            </section>
+        </div>
     </article>
     <aside>
         <h2>Sidebar</h2>

--- a/events/calendars/calendars.html
+++ b/events/calendars/calendars.html
@@ -5,31 +5,42 @@ title: Event Calendars
 
 <main>
     <article>
-        <h1>Event Calendars</h1>
-        <a href="eastofengland/eastofengland.html">
-            <h2>East of England</h2>
-        </a>
-        <a href="midlands/midlands.html">
-            <h2>Midlands</h2>
-        </a>
-        <a href="northeastengland/northeastengland.html">
-            <h2>North East England</h2>
-        </a>
-        <a href="northwalesandthenorthwest/northwalesandthenorthwest.html">
-            <h2>North Wales and the North West</h2>
-        </a>
-        <a href="northernirelandandroi/northernirelandandroi.html">
-            <h2>Northern Ireland and RoI</h2>
-        </a>
-        <a href="scotland/scotland.html">
-            <h2>Scotland</h2>
-        </a>
-        <a href="southeastengland/southeastengland.html">
-            <h2>South East England</h2>
-        </a>
-        <a href="southwalesandthesouthwest/southwalesandthesouthwest.html">
-            <h2>South Wales and the South West</h2>
-        </a>
+        <ol id="breadcrumb">
+            <li>
+                <a href="{{ site.baseurl }}/index.html">Home</a>
+            </li>
+            <li>
+                <a href="{{ site.baseurl }}/events/events.html">Events</a>
+            </li>
+            <li>Calendars</li>
+        </ol>
+        <div id="content">
+            <h1>Event Calendars</h1>
+            <a href="eastofengland/eastofengland.html">
+                <h2>East of England</h2>
+            </a>
+            <a href="midlands/midlands.html">
+                <h2>Midlands</h2>
+            </a>
+            <a href="northeastengland/northeastengland.html">
+                <h2>North East England</h2>
+            </a>
+            <a href="northwalesandthenorthwest/northwalesandthenorthwest.html">
+                <h2>North Wales and the North West</h2>
+            </a>
+            <a href="northernirelandandroi/northernirelandandroi.html">
+                <h2>Northern Ireland and RoI</h2>
+            </a>
+            <a href="scotland/scotland.html">
+                <h2>Scotland</h2>
+            </a>
+            <a href="southeastengland/southeastengland.html">
+                <h2>South East England</h2>
+            </a>
+            <a href="southwalesandthesouthwest/southwalesandthesouthwest.html">
+                <h2>South Wales and the South West</h2>
+            </a>
+        </div>
     </article>
     <aside>
         <section>

--- a/events/calendars/eastofengland/eastofengland.html
+++ b/events/calendars/eastofengland/eastofengland.html
@@ -1,5 +1,6 @@
 ---
 layout: emptycalendar
 title: East of England Events
-region: the East of England
+region: East of England
+prefix: "the "
 ---

--- a/events/calendars/midlands/midlands.html
+++ b/events/calendars/midlands/midlands.html
@@ -5,8 +5,22 @@ title: Midlands Events
 
 <main>
     <article>
-        <h1>Events in the Midlands</h1>
-        <p>Page content...</p>
+        <ol id="breadcrumb">
+            <li>
+                <a href="{{ site.baseurl }}/index.html">Home</a>
+            </li>
+            <li>
+                <a href="{{ site.baseurl }}/events/events.html">Events</a>
+            </li>
+            <li>
+                <a href="{{ site.baseurl }}/events/calendars/calendars.html">Calendars</a>
+            </li>
+            <li>Midlands</li>
+        </ol>
+        <div id="content">
+            <h1>Events in the Midlands</h1>
+            <p>Page content...</p>
+        </div>
     </article>
     <aside>
         <section>

--- a/events/calendars/southwalesandthesouthwest/southwalesandthesouthwest.html
+++ b/events/calendars/southwalesandthesouthwest/southwalesandthesouthwest.html
@@ -5,211 +5,225 @@ title: South Wales and the South West Events
 
 <main>
     <article>
-        <h1>Events in South Wales and the South West</h1>
-        <section>
-            <h2>2017</h2>
+        <ol id="breadcrumb">
+            <li>
+                <a href="{{ site.baseurl }}/index.html">Home</a>
+            </li>
+            <li>
+                <a href="{{ site.baseurl }}/events/events.html">Events</a>
+            </li>
+            <li>
+                <a href="{{ site.baseurl }}/events/calendars/calendars.html">Calendars</a>
+            </li>
+            <li>South Wales and the South West</li>
+        </ol>
+        <div id="content">
+            <h1>Events in South Wales and the South West</h1>
             <section>
-                <h3>August</h3>
-                <table>
-                    <thead>
-                        <tr>
-                            <th>Date</th>
-                            <th>Time</th>
-                            <th>Event</th>
-                            <th>Location</th>
-                            <th>Postcode</th>
-                            <th>Organiser/contact</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td class="noWrap">24<sup>th</sup>-28<sup>th</sup></td>
-                            <td></td>
-                            <td>Great Dorset Steam Fair</td>
-                            <td>Tarrant Hinton near Blandford Camp</td>
-                            <td class="noWrap">DT11 8JA</td>
-                            <td><a href="http://www.gdsf.co.uk/">http://www.gdsf.co.uk/</a> (Martin Oliver)</td>
-                        </tr>
-                        <tr>
-                            <td class="noWrap">26<sup>th</sup></td>
-                            <td>10:00-17:00</td>
-                            <td>Gloucester Goes Retro</td>
-                            <td>Gloucester</td>
-                            <td class="noWrap">GL1 2DH</td>
-                            <td><a href="mailto:colin.organ@gloucester.gov.uk?subject=Gloucester%20Goes%20Retro">colin.organ@gloucester.gov.uk</a></td>
-                        </tr>
-                        <tr>
-                            <td class="noWrap">27<sup>th</sup></td>
-                            <td>09:00-12:00</td>
-                            <td>Cheese and Grain “Classic”</td>
-                            <td>Market Yard, Frome</td>
-                            <td class="noWrap">BA11 1BE</td>
-                            <td><a href="mailto:robertg.powell@btinternet.com?subject=Cheese%20and%20Grain%20“Classic”">robertg.powell@btinternet.com</a></td>
-                        </tr>
-                        <tr>
-                            <td class="noWrap">27<sup>th</sup></td>
-                            <td>Arr 13:30-14:30</td>
-                            <td>Ponthir Music & Car Festival</td>
-                            <td>On field behind Star Pub</td>
-                            <td class="noWrap">NP18 1GA</td>
-                            <td>Andy on <a href="tel:+447771852703">(07771) 852703</a></td>
-                        </tr>
-                        <tr>
-                            <td class="noWrap">27<sup>th</sup>-28<sup>th</sup></td>
-                            <td></td>
-                            <td>Blaenavon Transport Rally</td>
-                            <td>Railway Station, Blaenavon, Pontypool</td>
-                            <td class="noWrap">NP4 9SF</td>
-                            <td>Sandra Harris on <a href="tel:+441633892693">(01633) 892693</a></td>
-                        </tr>
-                        <tr>
-                            <td class="noWrap">27<sup>th</sup>-28<sup>th</sup></td>
-                            <td>10:00-16:00</td>
-                            <td>Classic Motor Show – Devon</td>
-                            <td>Ugbrooke House, Chudleigh</td>
-                            <td class="noWrap">TQ13 0AD</td>
-                            <td><a href="mailto:richard.giesens.itus@hotmail.com?subject=Classic%20Motor%20Show%20–%20Devon">richard.giesens.itus@hotmail.com</a></td>
-                        </tr>
-                        <tr>
-                            <td class="noWrap">28<sup>th</sup></td>
-                            <td>11:00</td>
-                            <td>Welsh Get-together (BMC, BL and MG meeting)</td>
-                            <td>Ynysangharad Park, Pontypridd</td>
-                            <td class="noWrap"></td>
-                            <td></td>
-                        </tr>
-                    </tbody>
-                </table>
+                <h2>2017</h2>
+                <section>
+                    <h3>August</h3>
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Date</th>
+                                <th>Time</th>
+                                <th>Event</th>
+                                <th>Location</th>
+                                <th>Postcode</th>
+                                <th>Organiser/contact</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td class="noWrap">24<sup>th</sup>-28<sup>th</sup></td>
+                                <td></td>
+                                <td>Great Dorset Steam Fair</td>
+                                <td>Tarrant Hinton near Blandford Camp</td>
+                                <td class="noWrap">DT11 8JA</td>
+                                <td><a href="http://www.gdsf.co.uk/">http://www.gdsf.co.uk/</a> (Martin Oliver)</td>
+                            </tr>
+                            <tr>
+                                <td class="noWrap">26<sup>th</sup></td>
+                                <td>10:00-17:00</td>
+                                <td>Gloucester Goes Retro</td>
+                                <td>Gloucester</td>
+                                <td class="noWrap">GL1 2DH</td>
+                                <td><a href="mailto:colin.organ@gloucester.gov.uk?subject=Gloucester%20Goes%20Retro">colin.organ@gloucester.gov.uk</a></td>
+                            </tr>
+                            <tr>
+                                <td class="noWrap">27<sup>th</sup></td>
+                                <td>09:00-12:00</td>
+                                <td>Cheese and Grain “Classic”</td>
+                                <td>Market Yard, Frome</td>
+                                <td class="noWrap">BA11 1BE</td>
+                                <td><a href="mailto:robertg.powell@btinternet.com?subject=Cheese%20and%20Grain%20“Classic”">robertg.powell@btinternet.com</a></td>
+                            </tr>
+                            <tr>
+                                <td class="noWrap">27<sup>th</sup></td>
+                                <td>Arr 13:30-14:30</td>
+                                <td>Ponthir Music &amp; Car Festival</td>
+                                <td>On field behind Star Pub</td>
+                                <td class="noWrap">NP18 1GA</td>
+                                <td>Andy on <a href="tel:+447771852703">(07771) 852703</a></td>
+                            </tr>
+                            <tr>
+                                <td class="noWrap">27<sup>th</sup>-28<sup>th</sup></td>
+                                <td></td>
+                                <td>Blaenavon Transport Rally</td>
+                                <td>Railway Station, Blaenavon, Pontypool</td>
+                                <td class="noWrap">NP4 9SF</td>
+                                <td>Sandra Harris on <a href="tel:+441633892693">(01633) 892693</a></td>
+                            </tr>
+                            <tr>
+                                <td class="noWrap">27<sup>th</sup>-28<sup>th</sup></td>
+                                <td>10:00-16:00</td>
+                                <td>Classic Motor Show – Devon</td>
+                                <td>Ugbrooke House, Chudleigh</td>
+                                <td class="noWrap">TQ13 0AD</td>
+                                <td><a href="mailto:richard.giesens.itus@hotmail.com?subject=Classic%20Motor%20Show%20–%20Devon">richard.giesens.itus@hotmail.com</a></td>
+                            </tr>
+                            <tr>
+                                <td class="noWrap">28<sup>th</sup></td>
+                                <td>11:00</td>
+                                <td>Welsh Get-together (BMC, BL and MG meeting)</td>
+                                <td>Ynysangharad Park, Pontypridd</td>
+                                <td class="noWrap"></td>
+                                <td></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </section>
+                <section>
+                    <h3>September</h3>
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Date</th>
+                                <th>Time</th>
+                                <th>Event</th>
+                                <th>Location</th>
+                                <th>Postcode</th>
+                                <th>Organiser/contact</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td class="noWrap"></td>
+                                <td></td>
+                                <td></td>
+                                <td></td>
+                                <td class="noWrap"></td>
+                                <td></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </section>
+                <section>
+                    <h3>October</h3>
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Date</th>
+                                <th>Time</th>
+                                <th>Event</th>
+                                <th>Location</th>
+                                <th>Postcode</th>
+                                <th>Organiser/contact</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td class="noWrap"></td>
+                                <td></td>
+                                <td></td>
+                                <td></td>
+                                <td class="noWrap"></td>
+                                <td></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </section>
+                <section>
+                    <h3>November</h3>
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Date</th>
+                                <th>Time</th>
+                                <th>Event</th>
+                                <th>Location</th>
+                                <th>Postcode</th>
+                                <th>Organiser/contact</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td class="noWrap"></td>
+                                <td></td>
+                                <td></td>
+                                <td></td>
+                                <td class="noWrap"></td>
+                                <td></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </section>
+                <section>
+                    <h3>December</h3>
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Date</th>
+                                <th>Time</th>
+                                <th>Event</th>
+                                <th>Location</th>
+                                <th>Postcode</th>
+                                <th>Organiser/contact</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td class="noWrap"></td>
+                                <td></td>
+                                <td></td>
+                                <td></td>
+                                <td class="noWrap"></td>
+                                <td></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </section>
             </section>
             <section>
-                <h3>September</h3>
-                <table>
-                    <thead>
-                        <tr>
-                            <th>Date</th>
-                            <th>Time</th>
-                            <th>Event</th>
-                            <th>Location</th>
-                            <th>Postcode</th>
-                            <th>Organiser/contact</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td class="noWrap"></td>
-                            <td></td>
-                            <td></td>
-                            <td></td>
-                            <td class="noWrap"></td>
-                            <td></td>
-                        </tr>
-                    </tbody>
-                </table>
+                <h2>2018</h2>
+                <section>
+                    <h3>March</h3>
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Date</th>
+                                <th>Time</th>
+                                <th>Event</th>
+                                <th>Location</th>
+                                <th>Postcode</th>
+                                <th>Organiser/contact</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td class="noWrap"></td>
+                                <td></td>
+                                <td></td>
+                                <td></td>
+                                <td class="noWrap"></td>
+                                <td></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </section>
             </section>
-            <section>
-                <h3>October</h3>
-                <table>
-                    <thead>
-                        <tr>
-                            <th>Date</th>
-                            <th>Time</th>
-                            <th>Event</th>
-                            <th>Location</th>
-                            <th>Postcode</th>
-                            <th>Organiser/contact</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td class="noWrap"></td>
-                            <td></td>
-                            <td></td>
-                            <td></td>
-                            <td class="noWrap"></td>
-                            <td></td>
-                        </tr>
-                    </tbody>
-                </table>
-            </section>
-            <section>
-                <h3>November</h3>
-                <table>
-                    <thead>
-                        <tr>
-                            <th>Date</th>
-                            <th>Time</th>
-                            <th>Event</th>
-                            <th>Location</th>
-                            <th>Postcode</th>
-                            <th>Organiser/contact</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td class="noWrap"></td>
-                            <td></td>
-                            <td></td>
-                            <td></td>
-                            <td class="noWrap"></td>
-                            <td></td>
-                        </tr>
-                    </tbody>
-                </table>
-            </section>
-            <section>
-                <h3>December</h3>
-                <table>
-                    <thead>
-                        <tr>
-                            <th>Date</th>
-                            <th>Time</th>
-                            <th>Event</th>
-                            <th>Location</th>
-                            <th>Postcode</th>
-                            <th>Organiser/contact</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td class="noWrap"></td>
-                            <td></td>
-                            <td></td>
-                            <td></td>
-                            <td class="noWrap"></td>
-                            <td></td>
-                        </tr>
-                    </tbody>
-                </table>
-            </section>
-        </section>
-        <section>
-            <h2>2018</h2>
-            <section>
-                <h3>March</h3>
-                <table>
-                    <thead>
-                        <tr>
-                            <th>Date</th>
-                            <th>Time</th>
-                            <th>Event</th>
-                            <th>Location</th>
-                            <th>Postcode</th>
-                            <th>Organiser/contact</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td class="noWrap"></td>
-                            <td></td>
-                            <td></td>
-                            <td></td>
-                            <td class="noWrap"></td>
-                            <td></td>
-                        </tr>
-                    </tbody>
-                </table>
-            </section>
-        </section>
+        </div>
     </article>
     <aside>
         <section>

--- a/events/events.html
+++ b/events/events.html
@@ -5,22 +5,30 @@ title: Events
 
 <main>
     <article>
-        <h1>Events</h1>
-        <section>
-            <a href="rallies/rallies.html">
-                <h2>Rallies</h2>
-            </a>
-        </section>
-        <section>
-            <a href="local/local.html">
-                <h2>Local events</h2>
-            </a>
-        </section>
-        <section>
-            <a href="calendars/calendars.html">
-                <h2>Event calendars</h2>
-            </a>
-        </section>
+        <ol id="breadcrumb">
+            <li>
+                <a href="{{ site.baseurl }}/index.html">Home</a>
+            </li>
+            <li>Events</li>
+        </ol>
+        <div id="content">
+            <h1>Events</h1>
+            <section>
+                <a href="rallies/rallies.html">
+                    <h2>Rallies</h2>
+                </a>
+            </section>
+            <section>
+                <a href="local/local.html">
+                    <h2>Local events</h2>
+                </a>
+            </section>
+            <section>
+                <a href="calendars/calendars.html">
+                    <h2>Event calendars</h2>
+                </a>
+            </section>
+        </div>
     </article>
     <aside>
         <h2>Sidebar</h2>

--- a/events/local/local.html
+++ b/events/local/local.html
@@ -5,8 +5,19 @@ title: Local Events
 
 <main>
     <article>
-        <h1>Local Events</h1>
-        <p>Page content...</p>
+        <ol id="breadcrumb">
+            <li>
+                <a href="{{ site.baseurl }}/index.html">Home</a>
+            </li>
+            <li>
+                <a href="{{ site.baseurl }}/events/events.html">Events</a>
+            </li>
+            <li>Local</li>
+        </ol>
+        <div id="content">
+            <h1>Local Events</h1>
+            <p>Page content...</p>
+        </div>
     </article>
     <aside>
         <h2>Sidebar</h2>

--- a/events/rallies/northernrally2015/northernrally2015.html
+++ b/events/rallies/northernrally2015/northernrally2015.html
@@ -6,87 +6,101 @@ title: Northern Rally 2015
 <link href="northernrally2015.css" rel="stylesheet" type="text/css">
 <main>
     <article>
-        <h1>Northern Rally – Ripon Racecourse</h1>
-        <h2>26<sup>th</sup> July 2015</h2>
-        <section>
-            <p>Racing moved to this course in Boroughbridge Road in 1900 to establish Ripon as a regular flat racing venue, and due to its most pleasant surroundings, Ripon is known as Yorkshires Garden Racecourse. The racecourse it is now regarded as the sporting flagship of this medieval market town.</p>
-            <img class="fullWidthArticleImage" src="image1.jpg">
-        </section>
-        <section>
-            <h3>Rally report by Chad Brown</h3>
-            <img class="rightArticleImage" src="image2.jpg" width="200px">
-            <p>SUNDAY, JULY 26, saw a break with recent tradition, pardon the oxymoron, for the Triumph Mayflower Club in that we stood alone from the usual regular clubs with whom we usually share.</p>
-            <p>With the backing of a great established car show, Ripon Old Cars, at the Ripon Racecourse the scene was set for a great day.</p>
-            <p>A laminated weatherproof agenda was issued to all arrivals, just as well, plus a Mayflower key fob and the show itself issued plaques to commemorate the occasion.</p>
-            <p>Our club was independently awarded the “Best Club Stand” plaque at the conclusion of the show but more about that later.</p>
-            <img class="leftArticleImage" src="image3.jpg" width="300px">
-            <p>As rally secretary I was delighted to have nine Mayflowers in attendance and they were as follows: MSK 624 owned by Brian Redshaw, our New and Second hand Spares Secretary, who was awarded the trophy for Best Original Car.</p>
-            <p>BDX 929, also owned by Brian, thank you for going to the trouble of bringing two cars and thanks to your son who made it possible and also attended the spares stall.</p>
-            <p>ESK 253, owned by Tony Mason, a fairly recent acquisition and a lovely looking car. It won the well-deserved Best Car in Show. Tony made an early decision to disable the Trafficators in favour of a flashing unit on the grounds that it is dangerous but they were still in place, just not functioning.</p>
-            <img class="fullWidthArticleImage" src="image4.jpg">
-            <p>KSK 160, owned by Mike Clement from Selby in Yorkshire.</p>
-            <p>617 YUA, Little Nell, owned and cherished by yours truly, Vice Chairman and Rally Secretary, who was awarded the Chairman’s Cup for work in setting up the rally.</p>
-            <img class="rightArticleImage" src="image5.jpg" width="300px">
-            <p>PWJ 737, owned by Steve Watts from Beverley who also has named his car Percy. At least I hope he has since I have that name in my notes.</p>
-            <p>JVJ 170, owned by Robert Hustwick from Haworth, sadly without his son today, the future of the club.</p>
-            <p>HFN 261, owned by Arthur Patterson from (I’m not sure as I can’t read my own writing but it’s a long way away from Ripon as he won the Long-distance Award). [Accepted by Mrs. Patterson].</p>
-            <img class="rightArticleImage" src="image6.jpg" width="300px">
-            <p>ASY 787, owned by Alan Kormes from Bradford.</p>
-            <p>CSN 107, owned by Keith Pegram was there in spirit just in case those good at maths will have noticed he is number ten out of nine cars that were present!</p>
-            <p>I would like to say it was a ground breaking success, which it was for my short experience as Rally Secretary and we won the Best Club Stand award which is worth boasting over.</p>
-            <p>Sadly the weather was not on our side and shortly after our water protected laminated programme was finished the heavens opened and the rain set in for the remainder of the day.</p>
-            <p>The queue to get out of the ground was much greater than getting in and a few of us watched it from the comfort of our own club tent. That was essential as we needed to be on hand at the conclusion of the show to accept our award handed to life president Peter Benfield who has held a Mayflower presence at this show for many years.</p>
-            <img class="fullWidthArticleImage" src="image7.jpg">
-            <p>My thanks go to Peter Benfield who arranged the site and distributed entrance tickets; to John Castle who set up the prize winning display; to John Banks who did the programmes and took the photographs and to all owners who travelled, despite the forecast.</p>
-            <p>Next year I am pursuing the idea of standing alone for our shows, with a suitable back-up venue to add to your entertainment. I have hopes of interesting the Coventry Motor Museum or a revived Stoneleigh Park venue and will keep you informed.</p>
-            <p>I have discussed with our Chairman, who also acts as Regalia Secretary just now, of launching in 2016 an annual Mayflower Mileage contest with the most travelled member with the Mayflower and a self chosen piece of regalia and cup to be awarded at our show.</p>
-            <p>As administrator I will not be included in winning so you don’t have to compete with Little Nell who travels a lot.</p>
-            <p>On a final note of discussion I would love to know your views on Tony Mason’s fear about the danger of using old fashioned Trafficators and just how many members name their treasured possession. Floods of letters please to the editor.</p>
-            <div>
-                <img class="fullWidthArticleImage" src="image8.jpg">
-                <p class="imageCaption">Prize-winning club tent and Steve Watts’ Mayflower alongside.</p>
-            </div>
-        </section>
-        <section>
-            <h3>Gallery</h3>
-            <div id="gallery">
-                <div class="galleryRow">
-                    <div class="galleryImage">
-                        <img src="image9.jpg">
+        <ol id="breadcrumb">
+            <li>
+                <a href="{{ site.baseurl }}/index.html">Home</a>
+            </li>
+            <li>
+                <a href="{{ site.baseurl }}/events/events.html">Events</a>
+            </li>
+            <li>
+                <a href="{{ site.baseurl }}/events/rallies/rallies.html">Rallies</a>
+            </li>
+            <li>Northern Rally 2015</li>
+        </ol>
+        <div id="content">
+            <h1>Northern Rally – Ripon Racecourse</h1>
+            <h2>26<sup>th</sup> July 2015</h2>
+            <section>
+                <p>Racing moved to this course in Boroughbridge Road in 1900 to establish Ripon as a regular flat racing venue, and due to its most pleasant surroundings, Ripon is known as Yorkshires Garden Racecourse. The racecourse it is now regarded as the sporting flagship of this medieval market town.</p>
+                <img class="fullWidthArticleImage" src="image1.jpg">
+            </section>
+            <section>
+                <h3>Rally report by Chad Brown</h3>
+                <img class="rightArticleImage" src="image2.jpg" width="200px">
+                <p>SUNDAY, JULY 26, saw a break with recent tradition, pardon the oxymoron, for the Triumph Mayflower Club in that we stood alone from the usual regular clubs with whom we usually share.</p>
+                <p>With the backing of a great established car show, Ripon Old Cars, at the Ripon Racecourse the scene was set for a great day.</p>
+                <p>A laminated weatherproof agenda was issued to all arrivals, just as well, plus a Mayflower key fob and the show itself issued plaques to commemorate the occasion.</p>
+                <p>Our club was independently awarded the “Best Club Stand” plaque at the conclusion of the show but more about that later.</p>
+                <img class="leftArticleImage" src="image3.jpg" width="300px">
+                <p>As rally secretary I was delighted to have nine Mayflowers in attendance and they were as follows: MSK 624 owned by Brian Redshaw, our New and Second hand Spares Secretary, who was awarded the trophy for Best Original Car.</p>
+                <p>BDX 929, also owned by Brian, thank you for going to the trouble of bringing two cars and thanks to your son who made it possible and also attended the spares stall.</p>
+                <p>ESK 253, owned by Tony Mason, a fairly recent acquisition and a lovely looking car. It won the well-deserved Best Car in Show. Tony made an early decision to disable the Trafficators in favour of a flashing unit on the grounds that it is dangerous but they were still in place, just not functioning.</p>
+                <img class="fullWidthArticleImage" src="image4.jpg">
+                <p>KSK 160, owned by Mike Clement from Selby in Yorkshire.</p>
+                <p>617 YUA, Little Nell, owned and cherished by yours truly, Vice Chairman and Rally Secretary, who was awarded the Chairman’s Cup for work in setting up the rally.</p>
+                <img class="rightArticleImage" src="image5.jpg" width="300px">
+                <p>PWJ 737, owned by Steve Watts from Beverley who also has named his car Percy. At least I hope he has since I have that name in my notes.</p>
+                <p>JVJ 170, owned by Robert Hustwick from Haworth, sadly without his son today, the future of the club.</p>
+                <p>HFN 261, owned by Arthur Patterson from (I’m not sure as I can’t read my own writing but it’s a long way away from Ripon as he won the Long-distance Award). [Accepted by Mrs. Patterson].</p>
+                <img class="rightArticleImage" src="image6.jpg" width="300px">
+                <p>ASY 787, owned by Alan Kormes from Bradford.</p>
+                <p>CSN 107, owned by Keith Pegram was there in spirit just in case those good at maths will have noticed he is number ten out of nine cars that were present!</p>
+                <p>I would like to say it was a ground breaking success, which it was for my short experience as Rally Secretary and we won the Best Club Stand award which is worth boasting over.</p>
+                <p>Sadly the weather was not on our side and shortly after our water protected laminated programme was finished the heavens opened and the rain set in for the remainder of the day.</p>
+                <p>The queue to get out of the ground was much greater than getting in and a few of us watched it from the comfort of our own club tent. That was essential as we needed to be on hand at the conclusion of the show to accept our award handed to life president Peter Benfield who has held a Mayflower presence at this show for many years.</p>
+                <img class="fullWidthArticleImage" src="image7.jpg">
+                <p>My thanks go to Peter Benfield who arranged the site and distributed entrance tickets; to John Castle who set up the prize winning display; to John Banks who did the programmes and took the photographs and to all owners who travelled, despite the forecast.</p>
+                <p>Next year I am pursuing the idea of standing alone for our shows, with a suitable back-up venue to add to your entertainment. I have hopes of interesting the Coventry Motor Museum or a revived Stoneleigh Park venue and will keep you informed.</p>
+                <p>I have discussed with our Chairman, who also acts as Regalia Secretary just now, of launching in 2016 an annual Mayflower Mileage contest with the most travelled member with the Mayflower and a self chosen piece of regalia and cup to be awarded at our show.</p>
+                <p>As administrator I will not be included in winning so you don’t have to compete with Little Nell who travels a lot.</p>
+                <p>On a final note of discussion I would love to know your views on Tony Mason’s fear about the danger of using old fashioned Trafficators and just how many members name their treasured possession. Floods of letters please to the editor.</p>
+                <div>
+                    <img class="fullWidthArticleImage" src="image8.jpg">
+                    <p class="imageCaption">Prize-winning club tent and Steve Watts’ Mayflower alongside.</p>
+                </div>
+            </section>
+            <section>
+                <h3>Gallery</h3>
+                <div id="gallery">
+                    <div class="galleryRow">
+                        <div class="galleryImage">
+                            <img src="image9.jpg">
+                        </div>
+                        <div class="galleryImage">
+                            <img src="image10.jpg">
+                        </div>
                     </div>
-                    <div class="galleryImage">
-                        <img src="image10.jpg">
+                    <div class="galleryRow">
+                        <div class="galleryImage">
+                            <img src="image11.jpg">
+                        </div>
+                        <div class="galleryImage">
+                            <img src="image12.jpg">
+                        </div>
+                    </div>
+                    <div class="galleryRow">
+                        <div class="galleryImage">
+                            <img src="image13.jpg">
+                        </div>
+                        <div class="galleryImage">
+                            <img src="image14.jpg">
+                        </div>
+                    </div>
+                    <div class="galleryRow">
+                        <div class="galleryImage">
+                            <img src="image15.jpg">
+                        </div>
+                        <div class="galleryImage">
+                            <img src="image16.jpg">
+                        </div>
                     </div>
                 </div>
-                <div class="galleryRow">
-                    <div class="galleryImage">
-                        <img src="image11.jpg">
-                    </div>
-                    <div class="galleryImage">
-                        <img src="image12.jpg">
-                    </div>
-                </div>
-                <div class="galleryRow">
-                    <div class="galleryImage">
-                        <img src="image13.jpg">
-                    </div>
-                    <div class="galleryImage">
-                        <img src="image14.jpg">
-                    </div>
-                </div>
-                <div class="galleryRow">
-                    <div class="galleryImage">
-                        <img src="image15.jpg">
-                    </div>
-                    <div class="galleryImage">
-                        <img src="image16.jpg">
-                    </div>
-                </div>
-            </div>
-        </section>
+            </section>
+        </div>
     </article>
     <aside>
-        <h2>Members' cars in attendance</h2>
+        <h2>Members’ cars in attendance</h2>
         <ul class="disableListStyles">
             <li>
                 <h3>Chad Brown</h3>

--- a/events/rallies/rallies.html
+++ b/events/rallies/rallies.html
@@ -5,26 +5,37 @@ title: Rallies
 
 <main>
     <article>
-        <h1>Rallies</h1>
-        <section>
-            <h2>Upcoming rallies</h2>
-        </section>
-        <section>
-            <h2>Rally reports</h2>
+        <ol id="breadcrumb">
+            <li>
+                <a href="{{ site.baseurl }}/index.html">Home</a>
+            </li>
+            <li>
+                <a href="{{ site.baseurl }}/events/events.html">Events</a>
+            </li>
+            <li>Rallies</li>
+        </ol>
+        <div id="content">
+            <h1>Rallies</h1>
             <section>
-                <h3>2017</h3>
+                <h2>Upcoming rallies</h2>
             </section>
             <section>
-                <h3>2016</h3>
+                <h2>Rally reports</h2>
+                <section>
+                    <h3>2017</h3>
+                </section>
+                <section>
+                    <h3>2016</h3>
+                </section>
+                <section>
+                    <h3>2015</h3>
+                    <a href="northernrally2015/northernrally2015.html">Northern Rally – Ripon Racecourse (26<sup>th</sup> July)</a>
+                </section>
+                <section>
+                    <h3>2014</h3>
+                </section>
             </section>
-            <section>
-                <h3>2015</h3>
-                <a href="northernrally2015/northernrally2015.html">Northern Rally – Ripon Racecourse (26<sup>th</sup> July)</a>
-            </section>
-            <section>
-                <h3>2014</h3>
-            </section>
-        </section>
+        </div>
     </article>
     <aside>
         <h2>Sidebar</h2>

--- a/forum/forum.html
+++ b/forum/forum.html
@@ -5,8 +5,16 @@ title: Forum
 
 <main>
     <article>
-        <h1>Forum</h1>
-        <p>Page content...</p>
+        <ol id="breadcrumb">
+            <li>
+                <a href="{{ site.baseurl }}/index.html">Home</a>
+            </li>
+            <li>Forum</li>
+        </ol>
+        <div id="content">
+            <h1>Forum</h1>
+            <p>Page content...</p>
+        </div>
     </article>
     <aside>
         <h2>Sidebar</h2>

--- a/history/flowerpower/flowerpower.html
+++ b/history/flowerpower/flowerpower.html
@@ -5,8 +5,19 @@ title: History of Flower Power
 
 <main>
     <article>
-        <h1>History of Flower Power</h1>
-        <p>Page content...</p>
+        <ol id="breadcrumb">
+            <li>
+                <a href="{{ site.baseurl }}/index.html">Home</a>
+            </li>
+            <li>
+                <a href="{{ site.baseurl }}/history/history.html">History</a>
+            </li>
+            <li>Flower Power</li>
+        </ol>
+        <div id="content">
+            <h1>History of Flower Power</h1>
+            <p>Page content...</p>
+        </div>
     </article>
     <aside>
         <h2>Sidebar</h2>

--- a/history/history.html
+++ b/history/history.html
@@ -5,13 +5,21 @@ title: History
 
 <main>
     <article>
-        <h1>History</h1>
-        <section>
-            <a href="flowerpower/flowerpower.html">
-                <h2>Flower Power</h2>
-            </a>
-            <p>Section overview...</p>
-        </section>
+        <ol id="breadcrumb">
+            <li>
+                <a href="{{ site.baseurl }}/index.html">Home</a>
+            </li>
+            <li>History</li>
+        </ol>
+        <div id="content">
+            <h1>History</h1>
+            <section>
+                <a href="flowerpower/flowerpower.html">
+                    <h2>Flower Power</h2>
+                </a>
+                <p>Section overview...</p>
+            </section>
+        </div>
     </article>
     <aside>
         <h2>Sidebar</h2>

--- a/index.html
+++ b/index.html
@@ -5,19 +5,21 @@ layout: default
 <link href="index.css" rel="stylesheet" type="text/css">
 <main>
     <article>
-        <h1>About</h1>
-        <section>
-            <h2>The club</h2>
-            <p>The Triumph Mayflower Club, formed in 1974, exists to keep these wonderful and unique vehicles on the road and to provide a small part of the motoring heritage for the future. We aim to do this by encouraging ownership, promoting the vehicle to a wider audience and by pooling our enthusiasm, knowledge and known spares supplies. Above all else, we shall do this by helping each other to look after and improve our cars and so preserve them for the future.</p>
-        </section>
-        <section>
-            <h2>The Mayflower</h2>
-            <p>Information about the car...</p>
-        </section>
-        <section>
-            <h2>Triumph Motor Company</h2>
-            <p>Information about the company...</p>
-        </section>
+        <div id="content">
+            <h1>About</h1>
+            <section>
+                <h2>The club</h2>
+                <p>The Triumph Mayflower Club, formed in 1974, exists to keep these wonderful and unique vehicles on the road and to provide a small part of the motoring heritage for the future. We aim to do this by encouraging ownership, promoting the vehicle to a wider audience and by pooling our enthusiasm, knowledge and known spares supplies. Above all else, we shall do this by helping each other to look after and improve our cars and so preserve them for the future.</p>
+            </section>
+            <section>
+                <h2>The Mayflower</h2>
+                <p>Information about the car...</p>
+            </section>
+            <section>
+                <h2>Triumph Motor Company</h2>
+                <p>Information about the company...</p>
+            </section>
+        </div>
     </article>
     <aside>
         <div id="photos">

--- a/links/links.html
+++ b/links/links.html
@@ -5,12 +5,20 @@ title: Links
 
 <main>
     <article>
-        <h1>Links</h1>
-        <section>
-            <h2>Website source code</h2>
-            <h3>Hosted openly on GitHub – contributions welcome!</h3>
-            <a href="https://www.github.com/Stack-in-a-box/triumphmayflowerclub.com">https://www.github.com/Stack-in-a-box/triumphmayflowerclub.com</a>
-        </section>
+        <ol id="breadcrumb">
+            <li>
+                <a href="{{ site.baseurl }}/index.html">Home</a>
+            </li>
+            <li>Links</li>
+        </ol>
+        <div id="content">
+            <h1>Links</h1>
+            <section>
+                <h2>Website source code</h2>
+                <h3>Hosted openly on GitHub – contributions welcome!</h3>
+                <a href="https://www.github.com/Stack-in-a-box/triumphmayflowerclub.com">https://www.github.com/Stack-in-a-box/triumphmayflowerclub.com</a>
+            </section>
+        </div>
     </article>
     <aside>
         <h2>Sidebar</h2>

--- a/news/news.html
+++ b/news/news.html
@@ -5,8 +5,16 @@ title: News
 
 <main>
     <article>
-        <h1>News</h1>
-        <p>Page content...</p>
+        <ol id="breadcrumb">
+            <li>
+                <a href="{{ site.baseurl }}/index.html">Home</a>
+            </li>
+            <li>News</li>
+        </ol>
+        <div id="content">
+            <h1>News</h1>
+            <p>Page content...</p>
+        </div>
     </article>
     <aside>
         <h2>Sidebar</h2>

--- a/photos/events/events.html
+++ b/photos/events/events.html
@@ -5,12 +5,23 @@ title: Events Photos
 
 <main>
     <article>
-        <h1>Rallies and Events Photos</h1>
-        <a href="tmcannualrally2017/tmcannualrally2017.html">
-            <h2>Hanbury Hall, TMC Annual Rally – 11<sup>th</sup> June 2017</h2>
-        </a>
-        <h2>Hatfield House, TMC Annual Rally – 26<sup>th</sup> June 2016</h2>
-        <h2>RAF Cosford, TMC Annual Rally – 13<sup>th</sup> July 2014</h2>
+        <ol id="breadcrumb">
+            <li>
+                <a href="{{ site.baseurl }}/index.html">Home</a>
+            </li>
+            <li>
+                <a href="{{ site.baseurl }}/photos/photos.html">Photos</a>
+            </li>
+            <li>Rallies and Events</li>
+        </ol>
+        <div id="content">
+            <h1>Rallies and Events Photos</h1>
+            <a href="tmcannualrally2017/tmcannualrally2017.html">
+                <h2>Hanbury Hall, TMC Annual Rally – 11<sup>th</sup> June 2017</h2>
+            </a>
+            <h2>Hatfield House, TMC Annual Rally – 26<sup>th</sup> June 2016</h2>
+            <h2>RAF Cosford, TMC Annual Rally – 13<sup>th</sup> July 2014</h2>
+        </div>
     </article>
     <aside>
         <h2>Sidebar</h2>

--- a/photos/events/tmcannualrally2017/tmcannualrally2017.html
+++ b/photos/events/tmcannualrally2017/tmcannualrally2017.html
@@ -6,19 +6,33 @@ title: TMC Annual Rally 2017 Photos
 <link href="tmcannualrally2017.css" rel="stylesheet" type="text/css">
 <main>
     <article>
-        <h1>Hanbury Hall, TMC Annual Rally – 11<sup>th</sup> June 2017</h1>
-        <img src="1.jpg">
-        <img src="2.jpg">
-        <img src="3.jpg">
-        <img src="4.jpg">
-        <img src="5.jpg">
-        <img src="6.jpg">
-        <img src="7.jpg">
-        <img src="8.jpg">
-        <img src="9.jpg">
-        <img src="10.jpg">
-        <img src="11.jpg">
-        <img src="12.jpg">
+        <ol id="breadcrumb">
+            <li>
+                <a href="{{ site.baseurl }}/index.html">Home</a>
+            </li>
+            <li>
+                <a href="{{ site.baseurl }}/photos/photos.html">Photos</a>
+            </li>
+            <li>
+                <a href="{{ site.baseurl }}/photos/events/events.html">Rallies and Events</a>
+            </li>
+            <li>TMC Annual Rally 2017</li>
+        </ol>
+        <div id="content">
+            <h1>Hanbury Hall, TMC Annual Rally – 11<sup>th</sup> June 2017</h1>
+            <img src="1.jpg">
+            <img src="2.jpg">
+            <img src="3.jpg">
+            <img src="4.jpg">
+            <img src="5.jpg">
+            <img src="6.jpg">
+            <img src="7.jpg">
+            <img src="8.jpg">
+            <img src="9.jpg">
+            <img src="10.jpg">
+            <img src="11.jpg">
+            <img src="12.jpg">
+        </div>
     </article>
     <aside>
         <section>

--- a/photos/photos.html
+++ b/photos/photos.html
@@ -5,12 +5,20 @@ title: Photos
 
 <main>
     <article>
-        <h1>Photos</h1>
-        <a href="events/events.html">
-            <h2>Rallies and events</h2>
-        </a>
-        <h2>Members’ car builds</h2>
-        <h2>Other</h2>
+        <ol id="breadcrumb">
+            <li>
+                <a href="{{ site.baseurl }}/index.html">Home</a>
+            </li>
+            <li>Photos</li>
+        </ol>
+        <div id="content">
+            <h1>Photos</h1>
+            <a href="events/events.html">
+                <h2>Rallies and events</h2>
+            </a>
+            <h2>Members’ car builds</h2>
+            <h2>Other</h2>
+        </div>
     </article>
     <aside>
         <h2>Sidebar</h2>

--- a/shop/regalia/regalia.html
+++ b/shop/regalia/regalia.html
@@ -6,98 +6,109 @@ title: Regalia
 <link href="regalia.css" rel="stylesheet" type="text/css">
 <main>
     <article>
-        <h1>Regalia</h1>
-        <p>Page description...</p>
-        <div id="listings">
-            <div class="listingRow">
-                <section>
-                    <div class="listingDetails">
-                        <h2>Radiator badges – £18</h2>
-                    </div>
-                    <img src="radiatorbadges.jpg" alt="Radiator Badges">
-                </section>
-                <section>
-                    <h2>T-shirts – £10</h2>
-                    <img src="tshirts.jpg" alt="T-shirts">
-                </section>
-            </div>
-            <div class="listingRow">
-                <section>
-                    <div class="listingDetails">
-                        <h2>Sweatshirts – £22</h2>
-                    </div>
-                    <img src="sweatshirts.jpg" alt="Sweatshirts">
-                </section>
-                <section>
-                    <div class="listingDetails">
-                        <h2>Polo shirts – £15</h2>
-                    </div>
-                    <img src="polos.jpg" alt="Polo Shirts">
-                </section>
-            </div>
-            <div class="listingRow">
-                <section>
-                    <div class="listingDetails">
-                        <h2>Binders – £6</h2>
-                    </div>
-                    <img src="binders.jpg" alt="Binders">
-                </section>
-                <section>
-                    <div class="listingDetails">
-                        <h2>Caps – £10</h2>
-                    </div>
-                    <img src="caps.jpg" alt="Caps">
-                </section>
-            </div>
-            <div class="listingRow">
-                <section>
-                    <div class="listingDetails">
-                        <h2>Mouse mats – £6</h2>
-                    </div>
-                    <img src="mousemats.jpg" alt="Mouse Mats">
-                </section>
-                <section>
-                    <div class="listingDetails">
-                        <h2>Woven badges – £3</h2>
-                    </div>
-                    <div class="imagePlaceholder">Woven badges photo...</div>
-                </section>
-            </div>
-            <div class="listingRow">
-                <section>
-                    <div class="listingDetails">
-                        <h2>Key fobs – £3</h2>
-                    </div>
-                    <img src="keyfobs.jpg" alt="Key Fobs">
-                </section>
-                <section>
-                    <div class="listingDetails">
-                        <h2>Stickers – £1</h2>
-                    </div>
-                    <div class="imagePlaceholder">Stickers photo...</div>
-                </section>
-            </div>
-            <div class="listingRow">
-                <section>
-                    <div class="listingDetails">
-                        <h2>Lapel badges – £3</h2>
-                    </div>
-                    <div class="imagePlaceholder">Lapel badges photo...</div>
-                </section>
-                <section>
-                    <div class="listingDetails">
-                        <h2>Service manuals – £35</h2>
-                    </div>
-                    <img src="servicemanuals.jpg" alt="Service Manuals">
-                </section>
-            </div>
-            <div class="listingRow">
-                <section>
-                    <div class="listingDetails">
-                        <h2>Owners' handbooks – £10</h2>
-                    </div>
-                    <img src="ownershandbooks.jpg" alt="Owners' Handbooks">
-                </section>
+        <ol id="breadcrumb">
+            <li>
+                <a href="{{ site.baseurl }}/index.html">Home</a>
+            </li>
+            <li>
+                <a href="{{ site.baseurl }}/shop/shop.html">Shop</a>
+            </li>
+            <li>Regalia</li>
+        </ol>
+        <div id="content">
+            <h1>Regalia</h1>
+            <p>Page description...</p>
+            <div id="listings">
+                <div class="listingRow">
+                    <section>
+                        <div class="listingDetails">
+                            <h2>Radiator badges – £18</h2>
+                        </div>
+                        <img src="radiatorbadges.jpg" alt="Radiator Badges">
+                    </section>
+                    <section>
+                        <h2>T-shirts – £10</h2>
+                        <img src="tshirts.jpg" alt="T-shirts">
+                    </section>
+                </div>
+                <div class="listingRow">
+                    <section>
+                        <div class="listingDetails">
+                            <h2>Sweatshirts – £22</h2>
+                        </div>
+                        <img src="sweatshirts.jpg" alt="Sweatshirts">
+                    </section>
+                    <section>
+                        <div class="listingDetails">
+                            <h2>Polo shirts – £15</h2>
+                        </div>
+                        <img src="polos.jpg" alt="Polo Shirts">
+                    </section>
+                </div>
+                <div class="listingRow">
+                    <section>
+                        <div class="listingDetails">
+                            <h2>Binders – £6</h2>
+                        </div>
+                        <img src="binders.jpg" alt="Binders">
+                    </section>
+                    <section>
+                        <div class="listingDetails">
+                            <h2>Caps – £10</h2>
+                        </div>
+                        <img src="caps.jpg" alt="Caps">
+                    </section>
+                </div>
+                <div class="listingRow">
+                    <section>
+                        <div class="listingDetails">
+                            <h2>Mouse mats – £6</h2>
+                        </div>
+                        <img src="mousemats.jpg" alt="Mouse Mats">
+                    </section>
+                    <section>
+                        <div class="listingDetails">
+                            <h2>Woven badges – £3</h2>
+                        </div>
+                        <div class="imagePlaceholder">Woven badges photo...</div>
+                    </section>
+                </div>
+                <div class="listingRow">
+                    <section>
+                        <div class="listingDetails">
+                            <h2>Key fobs – £3</h2>
+                        </div>
+                        <img src="keyfobs.jpg" alt="Key Fobs">
+                    </section>
+                    <section>
+                        <div class="listingDetails">
+                            <h2>Stickers – £1</h2>
+                        </div>
+                        <div class="imagePlaceholder">Stickers photo...</div>
+                    </section>
+                </div>
+                <div class="listingRow">
+                    <section>
+                        <div class="listingDetails">
+                            <h2>Lapel badges – £3</h2>
+                        </div>
+                        <div class="imagePlaceholder">Lapel badges photo...</div>
+                    </section>
+                    <section>
+                        <div class="listingDetails">
+                            <h2>Service manuals – £35</h2>
+                        </div>
+                        <img src="servicemanuals.jpg" alt="Service Manuals">
+                    </section>
+                </div>
+                <div class="listingRow">
+                    <section>
+                        <div class="listingDetails">
+                            <h2>Owners' handbooks – £10</h2>
+                        </div>
+                        <img src="ownershandbooks.jpg" alt="Owners' Handbooks">
+                    </section>
+                </div>
             </div>
         </div>
     </article>

--- a/shop/shop.html
+++ b/shop/shop.html
@@ -5,14 +5,22 @@ title: Shop
 
 <main>
     <article>
-        <h1>Shop</h1>
-        <p>Page description...</p>
-        <section>
-            <a href="regalia/regalia.html">
-                <h2>Regalia</h2>
-            </a>
-            <p>Section blurb...</p>
-        </section>
+        <ol id="breadcrumb">
+            <li>
+                <a href="{{ site.baseurl }}/index.html">Home</a>
+            </li>
+            <li>Shop</li>
+        </ol>
+        <div id="content">
+            <h1>Shop</h1>
+            <p>Page description...</p>
+            <section>
+                <a href="regalia/regalia.html">
+                    <h2>Regalia</h2>
+                </a>
+                <p>Section blurb...</p>
+            </section>
+        </div>
     </article>
     <aside>
         <h2>Sidebar</h2>


### PR DESCRIPTION
The new breadcrumb bar will help people navigate the website as it grows as well as giving a clear view of the information hierarchy at a glance (especially important if the website is to become a comprehensive archive). Implemented on a separate branch to keep master usable for stakeholders when viewing the GitHub Pages staging area since this work includes a refactor that broke page layout until each individual page was updated.